### PR TITLE
Modified the manifest file to show how to retrieve a file from a zip 

### DIFF
--- a/Data/manifest.json
+++ b/Data/manifest.json
@@ -47,7 +47,7 @@
  "training_001_mr_T1.mha" : {
   "md5sum" : "04e76cef57966ac99ad4cee3b787b158"
  },
- "CIRS057A_MR_CT_DICOM.zip" : {
- "md5sum" : "f555722fcbc8f6f3690961f1b3054d18"
+ "CIRS057A_MR_CT_DICOM/readme.txt" : {
+ "md5sum" : "d92c97e6fe6520cb5b1a50b96eb9eb96"
  }
 }


### PR DESCRIPTION
The question on how to retrieve a file from an archive raised an issue I forgot about. The archive needs to be flat (set of files). You then specify the directory and file from the archive which you want. Same as with other MIDAS files. My old archive on MIDAS was not flat and this was an issue. I updated that on MIDAS and the example in the modified manifest shows how to get a file from the archive. 