### PR TITLE
Tweaks to Pythonic Image.

### DIFF
--- a/02_Pythonic_Image.ipynb
+++ b/02_Pythonic_Image.ipynb
@@ -1,436 +1,431 @@
 {
- "metadata": {
-  "name": ""
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "#Pythonic Syntactic Sugar\n",
-      "\n",
-      "The Image Basics Notebook was straight forward and closely follows ITK's C++ interface (albeit without those cumbersome templates).\n",
-      "\n",
-      "Sugar is great it gives your energy to get things done faster! SimpleITK has applied a generous about of syntactic sugar to help get things done faster too."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import matplotlib.pyplot as plt\n",
-      "%matplotlib inline\n",
-      "import SimpleITK as sitk\n",
-      "# Download data to work on\n",
-      "from downloaddata import fetch_data as fdata"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Let us begin by developing a convenient method for displaying images in our notebooks."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "img = sitk.GaussianSource(size=[64]*2)\n",
-      "plt.imshow(sitk.GetArrayFromImage(img))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "img = sitk.GaborSource(size=[64]*2, frequency=.03)\n",
-      "plt.imshow(sitk.GetArrayFromImage(img))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def myshow(img):\n",
-      "    nda = sitk.GetArrayFromImage(img)\n",
-      "    plt.imshow(nda)\n",
-      "myshow(img)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "##Multi-dimension slice indexing\n",
-      "\n",
-      "If you are familiar with numpy, sliced index then this should be cake for the SimpleITK image. The Python standard slice interface for 1-D object:\n",
-      "\n",
-      "<table>\n",
-      "    <tr><td>Operation</td>\t<td>Result</td></tr>\n",
-      "    <tr><td>d[i]</td>\t<td>ith item of d, starting index 0</td></tr>\n",
-      "    <tr><td>d[i:j]</td>\t<td>slice of d from i to j</td></tr>\n",
-      "    <tr><td>d[i:j:k]</td>\t<td>slice of d from i to j with step k</td></tr>\n",
-      "</table>\n",
-      "\n",
-      "With this convient syntax many basic tasks can be easily done."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "img[24,24]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Cropping"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(img[16:48,:])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(img[:,16:-16])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(img[:32,:32])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Flipping"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "img_corner = img[:32,:32]\n",
-      "myshow(img_corner)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(img_corner[::-1,:])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(sitk.Tile(img_corner, img_corner[::-1,::],img_corner[::,::-1],img_corner[::-1,::-1], [2,2]))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Slice Extraction\n",
-      "\n",
-      "A 2D image can be extracted from a 3D one."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "img = sitk.GaborSource(size=[64]*3, frequency=0.05)\n",
-      "\n",
-      "# Why does this produce an error?\n",
-      "myshow(img)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(img[:,:,32])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(img[16,:,:])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Super Sampling"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(img[:,::3,32])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "##Mathematical Operators\n",
-      "\n",
-      "Most python mathematical operators are overloaded to call the SimpleITK filter which does that same operation on a per-pixel basis. They can operate on a two images or an image and a scalar.\n",
-      "\n",
-      "If two images are used then both must have the same pixel type. The output image type is ussually the same.\n",
-      "\n",
-      "As these operators basically call ITK filter, which just use raw C++ operators, care must be taked to prevent overflow, and divide by zero etc.\n",
-      "\n",
-      "<table>\n",
-      "    <tr><td>Operators</td></tr>\n",
-      "    <tr><td>+</td></tr>\n",
-      "    <tr><td>-</td></tr>\n",
-      "    <tr><td>\\*</td></tr>\n",
-      "    <tr><td>/</td></tr>\n",
-      "    <tr><td>//</td></tr>\n",
-      "    <tr><td>**</td></tr>\n",
-      "<table>\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "img = sitk.ReadImage(fdata(\"cthead1.png\"))\n",
-      "img = sitk.Cast(img,sitk.sitkFloat32)\n",
-      "myshow(img)\n",
-      "img[150,150]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "timg = img**2\n",
-      "myshow(timg)\n",
-      "timg[150,150]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Division Operators\n",
-      "\n",
-      "All three Python division operators are implemented `__floordiv__`, `__truediv__`, and `__div__`.\n",
-      "\n",
-      "The true division's output is a double pixle type.\n",
-      "\n",
-      "See [PEP 238](http://www.python.org/peps/pep-0238) to see why Python changed the division operator in Python 3."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Bitwise Logic Operators\n",
-      "\n",
-      "<table>\n",
-      "    <tr><td>Operators</td></tr>\n",
-      "    <tr><td>&</td></tr>\n",
-      "    <tr><td>|</td></tr>\n",
-      "    <tr><td>^</td></tr>\n",
-      "    <tr><td>~</td></tr>\n",
-      "<table>"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "img = sitk.ReadImage(fdata(\"cthead1.png\"))\n",
-      "myshow(img)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "##Comparative Operators\n",
-      "<table>\n",
-      "    <tr><td>Operators</td></tr>\n",
-      "    <tr><td>\\></td></tr>\n",
-      "    <tr><td>\\>=</td></tr>\n",
-      "    <tr><td><</td></tr>\n",
-      "    <tr><td><=</td></tr>\n",
-      "    <tr><td>==</td></tr>\n",
-      "<table>\n",
-      "\n",
-      "These comparative operators follow the same convention as the reset of SimpleITK for binary images. They have the pixel type of ``sitkUInt8`` with values of 0 and 1. \n",
-      "    "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "img = sitk.ReadImage(fdata(\"cthead1.png\"))\n",
-      "myshow(img)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Amazingly make common trivial tasks really trivial"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(img>90)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow(img>150)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "myshow((img>90)+(img>150))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#Pythonic Syntactic Sugar\n",
+    "\n",
+    "The Image Basics Notebook was straight forward and closely follows ITK's C++ interface.\n",
+    "\n",
+    "Sugar is great it gives your energy to get things done faster! SimpleITK has applied a generous about of syntactic sugar to help get things done faster too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "mpl.rc('image', aspect='equal')\n",
+    "%matplotlib inline\n",
+    "import SimpleITK as sitk\n",
+    "# Download data to work on\n",
+    "from downloaddata import fetch_data as fdata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us begin by developing a convenient method for displaying images in our notebooks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img = sitk.GaussianSource(size=[64]*2)\n",
+    "plt.imshow(sitk.GetArrayFromImage(img))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img = sitk.GaborSource(size=[64]*2, frequency=.03)\n",
+    "plt.imshow(sitk.GetArrayFromImage(img))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def myshow(img):\n",
+    "    nda = sitk.GetArrayFromImage(img)\n",
+    "    plt.imshow(nda)\n",
+    "myshow(img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##Multi-dimension slice indexing\n",
+    "\n",
+    "If you are familiar with numpy, sliced index then this should be cake for the SimpleITK image. The Python standard slice interface for 1-D object:\n",
+    "\n",
+    "<table>\n",
+    "    <tr><td>Operation</td>\t<td>Result</td></tr>\n",
+    "    <tr><td>d[i]</td>\t<td>ith item of d, starting index 0</td></tr>\n",
+    "    <tr><td>d[i:j]</td>\t<td>slice of d from i to j</td></tr>\n",
+    "    <tr><td>d[i:j:k]</td>\t<td>slice of d from i to j with step k</td></tr>\n",
+    "</table>\n",
+    "\n",
+    "With this convient syntax many basic tasks can be easily done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img[24,24]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###Cropping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(img[16:48,:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(img[:,16:-16])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(img[:32,:32])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###Flipping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img_corner = img[:32,:32]\n",
+    "myshow(img_corner)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(img_corner[::-1,:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(sitk.Tile(img_corner, img_corner[::-1,::],img_corner[::,::-1],img_corner[::-1,::-1], [2,2]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###Slice Extraction\n",
+    "\n",
+    "A 2D image can be extracted from a 3D one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img = sitk.GaborSource(size=[64]*3, frequency=0.05)\n",
+    "\n",
+    "# Why does this produce an error?\n",
+    "myshow(img)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(img[:,:,32])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(img[16,:,:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###Super Sampling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(img[:,::3,32])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##Mathematical Operators\n",
+    "\n",
+    "Most python mathematical operators are overloaded to call the SimpleITK filter which does that same operation on a per-pixel basis. They can operate on a two images or an image and a scalar.\n",
+    "\n",
+    "If two images are used then both must have the same pixel type. The output image type is ussually the same.\n",
+    "\n",
+    "As these operators basically call ITK filter, which just use raw C++ operators, care must be taked to prevent overflow, and divide by zero etc.\n",
+    "\n",
+    "<table>\n",
+    "    <tr><td>Operators</td></tr>\n",
+    "    <tr><td>+</td></tr>\n",
+    "    <tr><td>-</td></tr>\n",
+    "    <tr><td>\\*</td></tr>\n",
+    "    <tr><td>/</td></tr>\n",
+    "    <tr><td>//</td></tr>\n",
+    "    <tr><td>**</td></tr>\n",
+    "<table>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img = sitk.ReadImage(fdata(\"cthead1.png\"))\n",
+    "img = sitk.Cast(img,sitk.sitkFloat32)\n",
+    "myshow(img)\n",
+    "img[150,150]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "timg = img**2\n",
+    "myshow(timg)\n",
+    "timg[150,150]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###Division Operators\n",
+    "\n",
+    "All three Python division operators are implemented `__floordiv__`, `__truediv__`, and `__div__`.\n",
+    "\n",
+    "The true division's output is a double pixle type.\n",
+    "\n",
+    "See [PEP 238](http://www.python.org/peps/pep-0238) to see why Python changed the division operator in Python 3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###Bitwise Logic Operators\n",
+    "\n",
+    "<table>\n",
+    "    <tr><td>Operators</td></tr>\n",
+    "    <tr><td>&</td></tr>\n",
+    "    <tr><td>|</td></tr>\n",
+    "    <tr><td>^</td></tr>\n",
+    "    <tr><td>~</td></tr>\n",
+    "<table>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img = sitk.ReadImage(fdata(\"cthead1.png\"))\n",
+    "myshow(img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##Comparative Operators\n",
+    "<table>\n",
+    "    <tr><td>Operators</td></tr>\n",
+    "    <tr><td>\\></td></tr>\n",
+    "    <tr><td>\\>=</td></tr>\n",
+    "    <tr><td><</td></tr>\n",
+    "    <tr><td><=</td></tr>\n",
+    "    <tr><td>==</td></tr>\n",
+    "<table>\n",
+    "\n",
+    "These comparative operators follow the same convention as the reset of SimpleITK for binary images. They have the pixel type of ``sitkUInt8`` with values of 0 and 1. \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img = sitk.ReadImage(fdata(\"cthead1.png\"))\n",
+    "myshow(img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###Amazingly make common trivial tasks really trivial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(img>90)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow(img>150)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "myshow((img>90)+(img>150))"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
Use matplotlib image.aspect 'equal' so the aspect ratio is display properly
for the sliced images.

Delete some empty cells.

Update the nbformat to 4.