### PR TITLE
Detailed notebook on segmentation evaluation.

### DIFF
--- a/34_Segmentation_Evaluation.ipynb
+++ b/34_Segmentation_Evaluation.ipynb
@@ -1,0 +1,351 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h1 align=\"center\">Segmentation Evaluation</h1>\n",
+    "\n",
+    "Evaluating segmentation algorithms is most often done using reference data to which you compare your results. \n",
+    "\n",
+    "In the medical domain reference data is commonly obtained via manual segmentation by an expert (don't forget to thank your clinical colleagues for their hard work). When you are resource limited, the reference data may be defined by a single expert. This is less than ideal. When multiple experts provide you with their input then you can potentially combine them to obtain reference data that is closer to the ever elusive \"ground truth\". In this notebook we show two approaches to combining input from multiple observers, majority vote and the Simultaneous Truth and Performance Level\n",
+    "Estimation [(STAPLE)](http://crl.med.harvard.edu/publications/warfield-staple-tmi-press-2004.pdf).\n",
+    "\n",
+    "Once we have a reference, we compare the algorithm's performance using multiple criteria, as usually there is no single evaluation measure that conveys all of the relevant information. In this notebook we illustrate the use of the following evaluation criteria:\n",
+    "* Overlap measures:\n",
+    "  * overlap percentage\n",
+    "  * jaccard and dice coefficients\n",
+    "  * volume similarity \n",
+    "  * false negative and false positive errors\n",
+    "* Surface distance measures:\n",
+    "  * Hausdorff distance (symmetric)\n",
+    "  * Mean, median, max and standard deviation between surfaces\n",
+    "  \n",
+    "The data we use in the notebook is a set of manully segmented liver tumors from a single clinical CT scan. A larger dataset (four scans) is freely available from this [MIDAS repository](http://www.insight-journal.org/midas/collection/view/38). The relevant publication is: T. Popa et al., \"Tumor Volume Measurement and Volume Measurement Comparison Plug-ins for VolView Using ITK\", SPIE Medical Imaging: Visualization, Image-Guided Procedures, and Display, 2006.\n",
+    "\n",
+    "<b>Note</b>: The approach described here can also be used to evaluate Registration, as illustrated in the [free form deformation notebook](65_Registration_FFD.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import SimpleITK as sitk\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "from downloaddata import fetch_data as fdata\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "from ipywidgets import interact, fixed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Utility method for display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "code_folding": [],
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def display_with_overlay(segmentation_number, slice_number, image, segs, window_min, window_max):\n",
+    "    \"\"\"\n",
+    "    Display a CT slice with segmented contours overlaid onto it. The contours are the edges of \n",
+    "    the labeled regions.\n",
+    "    \"\"\"\n",
+    "    img = image[:,:,slice_number]\n",
+    "    msk = segs[segmentation_number][:,:,slice_number]\n",
+    "    overlay_img = sitk.LabelMapContourOverlay(sitk.Cast(msk, sitk.sitkLabelUInt8), \n",
+    "                                              sitk.Cast(sitk.IntensityWindowing(img,\n",
+    "                                                                                windowMinimum=window_min, \n",
+    "                                                                                windowMaximum=window_max), \n",
+    "                                                        sitk.sitkUInt8), \n",
+    "                                             opacity = 1, \n",
+    "                                             contourThickness=[2,2])\n",
+    "    #We assume the original slice is isotropic, otherwise the display would be distorted \n",
+    "    plt.imshow(sitk.GetArrayFromImage(overlay_img))\n",
+    "    plt.axis('off')\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetch the data\n",
+    "\n",
+    "Retrieve a single CT scan and three manual deliniations of a liver tumor. Visual inspection of the data highlights the variability between experts. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "image = sitk.ReadImage(fdata(\"liverTumorSegmentations/Patient01Homo.mha\"))\n",
+    "segmentation_file_names = [\"liverTumorSegmentations/Patient01Homo_Rad01.mha\", \n",
+    "                          \"liverTumorSegmentations/Patient01Homo_Rad02.mha\",\n",
+    "                          \"liverTumorSegmentations/Patient01Homo_Rad03.mha\"]\n",
+    "                          \n",
+    "segmentations = [sitk.ReadImage(fdata(file_name), sitk.sitkUInt8) for file_name in segmentation_file_names]\n",
+    "    \n",
+    "interact(display_with_overlay, segmentation_number=(0,len(segmentations)-1), \n",
+    "         slice_number = (0, image.GetSize()[1]-1), image = fixed(image),\n",
+    "         segs = fixed(segmentations), window_min = fixed(-1024), window_max=fixed(976));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Derive a reference\n",
+    "\n",
+    "There are a variety of ways to derive a reference segmentaiton from multiple expert inputs. Several options, there are more, are described in \"A comparison of ground truth estimation methods\", A. M. Biancardi, A. C. Jirapatnakul, A. P. Reeves. \n",
+    "\n",
+    "Two methods that are available in SimpleITK are <b>majority vote</b> and the <b>STAPLE</b> algorithm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Use majority voting to obtain the reference segmentation. Note that this filter does not resolve ties. In case of \n",
+    "# ties, it will assign max_label_value+1 or a user specified label value (labelForUndecidedPixels) to the result. \n",
+    "# Before using the results of this filter you will have to check whether there were ties and modify the results to\n",
+    "# resolve the ties in a manner that makes sense for your task. The filter implicitly accomodates multiple labels.\n",
+    "labelForUndecidedPixels = 10\n",
+    "reference_segmentation_majority_vote = sitk.LabelVoting(segmentations, labelForUndecidedPixels)    \n",
+    "\n",
+    "manual_plus_majority_vote = list(segmentations)  \n",
+    "# Append the reference segmentation to the list of manual segmentations\n",
+    "manual_plus_majority_vote.append(reference_segmentation_majority_vote)\n",
+    "\n",
+    "interact(display_with_overlay, segmentation_number=(0,len(manual_plus_majority_vote)-1), \n",
+    "         slice_number = (0, image.GetSize()[1]-1), image = fixed(image),\n",
+    "         segs = fixed(manual_plus_majority_vote), window_min = fixed(-1024), window_max=fixed(976));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Use the STAPLE algorithm to obtain the reference segmentation. This implementation of the original algorithm\n",
+    "# combines a single label from multiple segmentations, the label is user specified. The result of the\n",
+    "# filter is the voxel's probability of belonging to the foreground. We then have to threshold the result to obtain\n",
+    "# a reference binary segmentation.\n",
+    "foregroundValue = 1\n",
+    "threshold = 0.95\n",
+    "reference_segmentation_STAPLE_probabilities = sitk.STAPLE(segmentations, foregroundValue) \n",
+    "# We use the overloaded operator to perform thresholding, another option is to use the BinaryThreshold function.\n",
+    "reference_segmentation_STAPLE = reference_segmentation_STAPLE_probabilities > threshold\n",
+    "\n",
+    "manual_plus_staple = list(segmentations)  \n",
+    "# Append the reference segmentation to the list of manual segmentations\n",
+    "manual_plus_staple.append(reference_segmentation_STAPLE)\n",
+    "\n",
+    "interact(display_with_overlay, segmentation_number=(0,len(manual_plus_staple)-1), \n",
+    "         slice_number = (0, image.GetSize()[1]-1), image = fixed(image),\n",
+    "         segs = fixed(manual_plus_staple), window_min = fixed(-1024), window_max=fixed(976));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluate segmentations using the reference\n",
+    "\n",
+    "Once we derive a reference from our experts input we can compare segmentation results to it.\n",
+    "\n",
+    "Note that in this notebook we compare the expert segmentations to the reference derived from them. This is not relevant for algorithm evaluation, but it can potentially be used to rank your experts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from enum import Enum\n",
+    "\n",
+    "# Use enumerations to represent the various evaluation measures\n",
+    "class OverlapMeasures(Enum):\n",
+    "    overlap_percentage, jaccard, dice, volume_similarity, false_negative, false_positive = range(6)\n",
+    "\n",
+    "class SurfaceDistanceMeasures(Enum):\n",
+    "    hausdorff_distance, mean_surface_distance, median_surface_distance, std_surface_distance, max_surface_distance = range(5)\n",
+    "    \n",
+    "# Select which reference we want to use (majority vote or STAPLE)    \n",
+    "reference_segmentation = reference_segmentation_STAPLE\n",
+    "\n",
+    "# Empty numpy arrays to hold the results \n",
+    "overlap_results = np.zeros((len(segmentations),len(OverlapMeasures.__members__.items())))  \n",
+    "surface_distance_results = np.zeros((len(segmentations),len(SurfaceDistanceMeasures.__members__.items())))  \n",
+    "\n",
+    "# Compute the evaluation criteria\n",
+    "\n",
+    "# Note that for the overlap measures filter, because we are dealing with a single label we \n",
+    "# use the combined, all labels, evaluation measures without passing a specific label to the methods.\n",
+    "overlap_measures_filter = sitk.LabelOverlapMeasuresImageFilter()\n",
+    "\n",
+    "hausdorff_distance_filter = sitk.HausdorffDistanceImageFilter()\n",
+    "\n",
+    "# Use the absolute values of the distance map to compute the surface distances (distance map sign, outside or inside \n",
+    "# relationship, is irrelevant)\n",
+    "reference_distance_map = sitk.Abs(sitk.SignedMaurerDistanceMap(reference_segmentation, squaredDistance=False))\n",
+    "label_intensity_statistics_filter = sitk.LabelIntensityStatisticsImageFilter()\n",
+    "label = 1\n",
+    "\n",
+    "for i, seg in enumerate(segmentations):\n",
+    "    # Overlap measures\n",
+    "    overlap_measures_filter.Execute(reference_segmentation, seg)\n",
+    "    overlap_results[i,OverlapMeasures.overlap_percentage.value] = overlap_measures_filter.GetMeanOverlap()\n",
+    "    overlap_results[i,OverlapMeasures.jaccard.value] = overlap_measures_filter.GetJaccardCoefficient()\n",
+    "    overlap_results[i,OverlapMeasures.dice.value] = overlap_measures_filter.GetDiceCoefficient()\n",
+    "    overlap_results[i,OverlapMeasures.volume_similarity.value] = overlap_measures_filter.GetVolumeSimilarity()\n",
+    "    overlap_results[i,OverlapMeasures.false_negative.value] = overlap_measures_filter.GetFalseNegativeError()\n",
+    "    overlap_results[i,OverlapMeasures.false_positive.value] = overlap_measures_filter.GetFalsePositiveError()\n",
+    "    # Hausdorff distance\n",
+    "    hausdorff_distance_filter.Execute(reference_segmentation, seg)\n",
+    "    surface_distance_results[i,SurfaceDistanceMeasures.hausdorff_distance.value] = hausdorff_distance_filter.GetHausdorffDistance()\n",
+    "    # Surface distance measures\n",
+    "    segmented_surface = sitk.LabelContour(seg)\n",
+    "    label_intensity_statistics_filter.Execute(segmented_surface, reference_distance_map)\n",
+    "    surface_distance_results[i,SurfaceDistanceMeasures.mean_surface_distance.value] = label_intensity_statistics_filter.GetMean(label)\n",
+    "    surface_distance_results[i,SurfaceDistanceMeasures.median_surface_distance.value] = label_intensity_statistics_filter.GetMedian(label)\n",
+    "    surface_distance_results[i,SurfaceDistanceMeasures.std_surface_distance.value] = label_intensity_statistics_filter.GetStandardDeviation(label)\n",
+    "    surface_distance_results[i,SurfaceDistanceMeasures.max_surface_distance.value] = label_intensity_statistics_filter.GetMaximum(label)\n",
+    "    \n",
+    "\n",
+    "# Print the matrices\n",
+    "np.set_printoptions(precision=3)\n",
+    "print(overlap_results)\n",
+    "print(surface_distance_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Improved output\n",
+    "\n",
+    "If the [pandas](http://pandas.pydata.org/) package is installed in your Python environment then you can easily produce high quality output. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from IPython.display import display, HTML \n",
+    "\n",
+    "# Graft our results matrix into pandas data frames \n",
+    "overlap_results_df = pd.DataFrame(data=overlap_results, index = list(range(len(segmentations))), \n",
+    "                                  columns=[name for name, _ in OverlapMeasures.__members__.items()]) \n",
+    "surface_distance_results_df = pd.DataFrame(data=surface_distance_results, index = list(range(len(segmentations))), \n",
+    "                                  columns=[name for name, _ in SurfaceDistanceMeasures.__members__.items()]) \n",
+    "\n",
+    "# Display the data as html tables and graphs\n",
+    "display(HTML(overlap_results_df.to_html(float_format=lambda x: '%.3f' % x)))\n",
+    "display(HTML(surface_distance_results_df.to_html(float_format=lambda x: '%.3f' % x)))\n",
+    "overlap_results_df.plot(kind='bar').legend(bbox_to_anchor=(1.6,0.9))\n",
+    "surface_distance_results_df.plot(kind='bar').legend(bbox_to_anchor=(1.6,0.9))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also export the data as a table for your LaTex manuscript usint the [to_latex](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_latex.html) function.\n",
+    "<b>Note</b>: You will need to add the \\usepackage{booktabs} to your LaTex document's preamble. \n",
+    "\n",
+    "To create the minimal LaTex document which will allow you to see the difference between the tables below, copy paste:\n",
+    "\n",
+    "\\documentclass{article}\n",
+    "\n",
+    "\\usepackage{booktabs}\n",
+    "\n",
+    "\\begin{document}\n",
+    "\n",
+    "paste the tables here\n",
+    "\n",
+    "\\end{document}\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# The formatting of the table using the default settings is less than ideal \n",
+    "print(overlap_results_df.to_latex())\n",
+    "\n",
+    "# We can improve on this by specifying the table's column format and the float format\n",
+    "print(overlap_results_df.to_latex(column_format='ccccccc', float_format=lambda x: '%.3f' % x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/65_Registration_FFD.ipynb
+++ b/65_Registration_FFD.ipynb
@@ -233,7 +233,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another option for evaluating the registration is to use segmentation. In this case, we transfer the segmentation from one image to the other and compare the overlaps, both visually, and quantitatively."
+    "Another option for evaluating the registration is to use segmentation. In this case, we transfer the segmentation from one image to the other and compare the overlaps, both visually, and quantitatively.\n",
+    "\n",
+    "<b>Note</b>: A more detailed version of the approach described here can be found in the [Segmentation Evaluation notebook](34_Segmentation_Evaluation.ipynb)."
    ]
   },
   {
@@ -288,21 +290,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
   }
  },
  "nbformat": 4,

--- a/Data/manifest.json
+++ b/Data/manifest.json
@@ -199,5 +199,17 @@
   "md5sum" : "4716b86ff1a213e8b92c4807ca9813a1",
   "url" : "http://tux.creatis.insa-lyon.fr/~srit/POPI/Masks/90Mask-MetaImage.tar",
   "archive" : "true"
+ },
+ "liverTumorSegmentations/Patient01Homo.mha" : {
+ "md5sum" : "dfc3efbd8c0d4b66792d22b75ec4cc18"
+ },
+ "liverTumorSegmentations/Patient01Homo_Rad01.mha" : {
+ "md5sum" : "76bd4cd0b9b0ca02612f66fa939a8b60"
+ },
+ "liverTumorSegmentations/Patient01Homo_Rad02.mha" : {
+ "md5sum" : "ac13f182d968fd09faf92604908d30f8"
+ },
+ "liverTumorSegmentations/Patient01Homo_Rad03.mha" : {
+ "md5sum" : "7a156c16e859d3eeb8ad31f59f4b2d96"
  }
 }

--- a/downloaddata.py
+++ b/downloaddata.py
@@ -183,6 +183,8 @@ def get_midas_servers():
         "http://www.itk.org/files/ExternalData/%(algo)/%(hash)",
         # Mirror supported by the Slicer community.
         "http://slicer.kitware.com/midas3/api/rest?method=midas.bitstream.download&checksum=%(hash)&algorithm=%(algo)",
+        # Insight journal data server
+        "http://www.insight-journal.org/midas/api/rest?method=midas.bitstream.by.hash&hash=%(hash)"
         ])
     return midas_servers
 


### PR DESCRIPTION
Added a notebook showing how to derive a reference segmentation from
multiple expert segmentations and how to evaluate a new segmentation
using the reference. Also cross-linked the new notebook with the FFD
registration where this approach is used to evaluate registration.