### PR TITLE
Adding a testing framework based on pytest to the repository.

### DIFF
--- a/Python/00_Setup.ipynb
+++ b/Python/00_Setup.ipynb
@@ -91,7 +91,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
    },
    "outputs": [],
    "source": [

--- a/Python/01_Image_Basics.ipynb
+++ b/Python/01_Image_Basics.ipynb
@@ -397,7 +397,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
    },
    "outputs": [],
    "source": [

--- a/Python/02_Pythonic_Image.ipynb
+++ b/Python/02_Pythonic_Image.ipynb
@@ -197,7 +197,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "simpleitk_error_expected": "Invalid dimensions for image data"
    },
    "outputs": [],
    "source": [

--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -455,7 +455,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "simpleitk_error_expected": "Inputs do not occupy the same physical space!"
    },
    "outputs": [],
    "source": [

--- a/Python/10_matplotlib's_imshow.ipynb
+++ b/Python/10_matplotlib's_imshow.ipynb
@@ -36,7 +36,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
    },
    "outputs": [],
    "source": [
@@ -48,7 +49,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
    },
    "outputs": [],
    "source": [
@@ -225,7 +227,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most filters which take multiple images as arguments require that the images occupy the same physical space. That is the pixel you are operating must refer to the same location."
+    "Most filters which take multiple images as arguments require that the images occupy the same physical space. That is the pixel you are operating must refer to the same location. Luckily for us our image and labels do occupy the same physical space, allowing us to overlay the segmentation onto the original image."
    ]
   },
   {
@@ -236,7 +238,6 @@
    },
    "outputs": [],
    "source": [
-    "# This fails because the images don't occupy the same physical scale.\n",
     "myshow(sitk.LabelOverlay(img1, img1_seg), title=\"Label Overlayed\")"
    ]
   },
@@ -244,18 +245,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ideally, this meta-data is retained, so images are consistent. However, the situation is not ideal, and image meta-data needs to be fixed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "img1_seg.CopyInformation(img1)"
+    "We can also display the labels as contours."
    ]
   },
   {

--- a/Python/31_Levelset_Segmentation.ipynb
+++ b/Python/31_Levelset_Segmentation.ipynb
@@ -35,7 +35,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
    },
    "outputs": [],
    "source": [

--- a/Python/33_Segmentation_Thresholding_Edge_Detection.ipynb
+++ b/Python/33_Segmentation_Thresholding_Edge_Detection.ipynb
@@ -48,7 +48,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
    },
    "outputs": [],
    "source": [
@@ -168,7 +169,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
    },
    "outputs": [],
    "source": [
@@ -269,7 +271,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
    },
    "outputs": [],
    "source": [

--- a/R/R_style_image.ipynb
+++ b/R/R_style_image.ipynb
@@ -175,7 +175,29 @@
    "metadata": {},
    "source": [
     "### Tiling (using slicing)\n",
-    "\n"
+    "\n",
+    "We cannot perform tiling via slicing directly on an image. The reason for this restriction is that an image is not equivalent to an array. Unlike an array, an image enforces the concept of physical spacing between pixels/voxels, this spacing has to be uniform for each of the axes. Thus a non-uniform slicing, e.g. (1,2,3,3,2,1), will generate an error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "simpleitk_error_expected": "spacing is not uniform"
+   },
+   "outputs": [],
+   "source": [
+    "corner[c(1:corner$GetWidth(), corner$GetWidth():1), c(1:corner$GetHeight(), corner$GetHeight():1)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can still easily perform the tiling operation we want by slightly abusing the system, converting the image to an array, performing the tiling and then converting the array back to an image. Note that the new image will have unit spacings for each axis, the concept of physical spacing is lost once we convert to an array.\n",
+    "\n",
+    "The correct, maintaining the data as an image, way of performing this operation is to use a SimpleITK filter as shown below."
    ]
   },
   {
@@ -186,7 +208,8 @@
    },
    "outputs": [],
    "source": [
-    "corner[c(1:corner$GetWidth(), corner$GetWidth():1), c(1:corner$GetHeight(), corner$GetHeight():1)]\n"
+    "arr = as.array(corner)\n",
+    "as.image(arr[c(1:corner$GetWidth(), corner$GetWidth():1), c(1:corner$GetHeight(), corner$GetHeight():1)])"
    ]
   },
   {
@@ -327,6 +350,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Flip the image, x axis. This also changes the x coordinate of the origin. When we try to add the two images we will fail, because they do not occupy the same physcial space. Again, SimpleITK images are not arrays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "simpleitk_error_expected": "Error in validObject"
+   },
+   "outputs": [],
+   "source": [
+    "flipped_img <- img[img$GetWidth():1, ]\n",
+    "img + flipped_img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we really want to add the intensity values of the two images, we can modify the meta-data of the flipped image to match that of the original. We know they have the same number of pixels on each axis, so we can do this safely."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -334,7 +384,8 @@
    },
    "outputs": [],
    "source": [
-    "img + img[img$GetWidth():1, ]"
+    "flipped_img$CopyInformation(img)\n",
+    "img + flipped_img"
    ]
   },
   {
@@ -399,6 +450,7 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
    "display_name": "R",
    "language": "R",

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,233 @@
+import os
+import subprocess
+import tempfile
+
+import nbformat
+
+"""
+run all tests:
+pytest -v --tb=short
+
+run specific test:
+pytest -v --tb=short tests/test_notebooks.py::Test_notebooks::test_10_matplotlibs_imshow
+"""
+
+class Test_notebooks(object):
+    """
+    Testing of SimpleITK Jupyter notebooks:
+    1. Check that notebooks do not contain output (sanity check as these should 
+       not have been pushed to the repository).
+    2. Run the notebook and check for errors. In some notebooks we 
+       intentionally cause errors to illustrate certain features of the toolkit. 
+       All code cells that intentionally generate an error are expected to be 
+       marked using the cell's metadata. In the notebook go to 
+       "View->Cell Toolbar->Edit Metadata and add the following json: 
+       
+       "simpleitk_error_expected": simpleitk_error_message
+
+       Cells where an error is allowed, but not necessarily expected should be marked
+       with the following json:
+
+       "simpleitk_error_allowed": simpleitk_error_message
+
+       The simpleitk_error_message is a substring of the generated error
+       message, such as 'Exception thrown in SimpleITK Show:'
+    """
+    def evaluate_notebook(self, path, kernel_name):
+        """
+        Execute a notebook via nbconvert and print the results of the test (errors etc.)
+        Args:
+            path (string): Name of notebook to run.
+            kernel_name (string): Which jupyter kernel to use to run the test. 
+                                  Relevant values are:'python2', 'python3', 'ir'.
+        """
+        allowed_error_markup = 'simpleitk_error_allowed'
+        expected_error_markup = 'simpleitk_error_expected'
+
+        dir_name, file_name = os.path.split(path)
+        if dir_name:
+            os.chdir(dir_name)
+
+        print('-------- begin (kernel {0}) {1} --------'.format(kernel_name,file_name))
+        
+        # Check that the notebook does not contain output from code cells 
+        # (should not be in the repository, but well...).
+        nb = nbformat.read(path, nbformat.current_nbformat)
+        no_unexpected_output = True
+        # Check that the cell dictionary has an 'outputs' key and that it is empty, relies
+        # on Python using short circuit evaluation so that we don't get KeyError when retrieving
+        # the 'outputs' entry.
+        cells_with_output = [c.source for c in nb.cells if 'outputs' in c and c.outputs]
+        if cells_with_output:
+            no_unexpected_output = False
+            print('Cells with unexpected output:')
+            for cell in cells_with_output: 
+                print(cell+'\n---')
+
+
+        # Execute the notebook and allow errors (run all cells), output is
+        # written to a temporary file which is automatically deleted.
+        with tempfile.NamedTemporaryFile(suffix='.ipynb') as fout:
+            args = ['jupyter', 'nbconvert', 
+                    '--to', 'notebook', 
+                    '--execute',
+                    '--ExecutePreprocessor.kernel_name='+kernel_name, 
+                    '--ExecutePreprocessor.allow_errors=True',
+                    '--ExecutePreprocessor.timeout=600', # seconds till timeout 
+                    '--output', fout.name, path]
+            subprocess.check_call(args)
+            nb = nbformat.read(fout.name, nbformat.current_nbformat)
+
+        # Get all of the unexpected errors (logic: cell has output with an error
+        # and no error is expected or the allowed/expected error is not the one which
+        # was generated.)
+        unexpected_errors = [(output.evalue, c.source) for c in nb.cells \
+                              if 'outputs' in c for output in c.outputs \
+                              if (output.output_type=='error') and \
+                               (((allowed_error_markup not in c.metadata) and (expected_error_markup not in c.metadata))or \
+                               ((allowed_error_markup in c.metadata) and (c.metadata[allowed_error_markup] not in output.evalue)) or \
+                               ((expected_error_markup in c.metadata) and (c.metadata[expected_error_markup] not in output.evalue)))]
+        
+        no_unexpected_errors = True 
+        if unexpected_errors:
+            no_unexpected_errors = False
+            print('Cells with unexpected errors:\n_____________________________')
+            for e, src in unexpected_errors:
+                print(src)
+                print('unexpected error: '+e)
+        else:
+            print('no unexpected errors')
+
+        # Get all of the missing expected errors (logic: cell has output
+        # but expected error was not generated.)
+        missing_expected_errors = []
+        for c in nb.cells:
+            if expected_error_markup in c.metadata:
+                missing_error = True
+                if 'outputs' in c:
+                    for output in c.outputs:
+                        if (output.output_type=='error') and (c.metadata[expected_error_markup] in output.evalue):
+                                missing_error = False
+                if missing_error:
+                    missing_expected_errors.append((c.metadata[expected_error_markup],c.source))
+
+        no_missing_expected_errors = True
+        if missing_expected_errors:
+            no_missing_expected_errors = False
+            print('\nCells with missing expected errors:\n___________________________________')
+            for e, src in missing_expected_errors:
+                print(src)
+                print('missing expected error: '+e)
+        else:
+            print('no missing expected errors')
+
+        print('-------- end (kernel {0}) {1} --------'.format(kernel_name,file_name))
+        assert(no_unexpected_output and no_unexpected_errors and no_missing_expected_errors)
+
+
+    def absolute_path_python(self, notebook_file_name):
+        return os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../Python', notebook_file_name))        
+
+    def absolute_path_r(self, notebook_file_name):
+        return os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../R', notebook_file_name))
+
+    #
+    # Python notebook testing.
+    #
+    def test_00_Setup_p(self):
+        self.evaluate_notebook(self.absolute_path_python('00_Setup.ipynb'), 'python3')
+
+    def test_01_Image_Basics_p(self):
+        self.evaluate_notebook(self.absolute_path_python('01_Image_Basics.ipynb'), 'python3')
+
+    def test_02_Pythonic_Image_p(self):
+        self.evaluate_notebook(self.absolute_path_python('02_Pythonic_Image.ipynb'), 'python3')
+
+    def test_03_Image_Details_p(self):
+        self.evaluate_notebook(self.absolute_path_python('03_Image_Details.ipynb'), 'python3')
+
+    def test_10_matplotlibs_imshow_p(self):
+        self.evaluate_notebook(self.absolute_path_python('10_matplotlib\'s_imshow.ipynb'), 'python3')
+
+    def test_20_Expand_With_Interpolators_p(self):
+        self.evaluate_notebook(self.absolute_path_python('20_Expand_With_Interpolators.ipynb'), 'python3')
+
+    def test_21_Transforms_and_Resampling_p(self):
+        self.evaluate_notebook(self.absolute_path_python('21_Transforms_and_Resampling.ipynb'), 'python3')
+
+    def test_22_Transforms_p(self):
+        self.evaluate_notebook(self.absolute_path_python('22_Transforms.ipynb'), 'python3')
+
+    def test_300_Segmentation_Overview_p(self):
+        self.evaluate_notebook(self.absolute_path_python('300_Segmentation_Overview.ipynb'), 'python3')
+
+    def test_30_Segmentation_Region_Growing_p(self):
+        self.evaluate_notebook(self.absolute_path_python('30_Segmentation_Region_Growing.ipynb'), 'python3')
+
+    def test_31_Levelset_Segmentation_p(self):
+        self.evaluate_notebook(self.absolute_path_python('31_Levelset_Segmentation.ipynb'), 'python3')
+
+    def test_32_Watersheds_Segmentation_p(self):
+        self.evaluate_notebook(self.absolute_path_python('32_Watersheds_Segmentation.ipynb'), 'python3')
+
+    def test_33_Segmentation_Thresholding_Edge_Detection_p(self):
+        self.evaluate_notebook(self.absolute_path_python('33_Segmentation_Thresholding_Edge_Detection.ipynb'), 'python3')
+
+    def test_34_Segmentation_Evaluation_p(self):
+        self.evaluate_notebook(self.absolute_path_python('34_Segmentation_Evaluation.ipynb'), 'python3')
+
+    # This notebook times out when run with nbconvert, due to javascript issues. We currently don't
+    # test it.
+    def test_41_Progress_p(self):
+        #self.evaluate_notebook(self.absolute_path_python('41_Progress.ipynb'), 'python3')
+        assert(True)
+
+    def test_51_VH_Segmentation1_p(self):
+        self.evaluate_notebook(self.absolute_path_python('51_VH_Segmentation1.ipynb'), 'python3')
+
+    def test_55_VH_Resample_p(self):
+        self.evaluate_notebook(self.absolute_path_python('55_VH_Resample.ipynb'), 'python3')
+
+    def test_56_VH_Registration1_p(self):
+        self.evaluate_notebook(self.absolute_path_python('56_VH_Registration1.ipynb'), 'python3')
+
+    def test_60_Registration_Introduction_p(self):
+        self.evaluate_notebook(self.absolute_path_python('60_Registration_Introduction.ipynb'), 'python3')
+
+    def test_61_Registration_Introduction_Continued_p(self):
+        self.evaluate_notebook(self.absolute_path_python('61_Registration_Introduction_Continued.ipynb'), 'python3')
+
+    def test_62_Registration_Tuning_p(self):
+        self.evaluate_notebook(self.absolute_path_python('62_Registration_Tuning.ipynb'), 'python3')
+
+    def test_63_Registration_Initialization_p(self):
+        self.evaluate_notebook(self.absolute_path_python('63_Registration_Initialization.ipynb'), 'python3')
+
+    def test_64_Registration_Memory_Time_Tradeoff_p(self):
+        self.evaluate_notebook(self.absolute_path_python('64_Registration_Memory_Time_Tradeoff.ipynb'), 'python3')
+
+    def test_65_Registration_FFD_p(self):
+        self.evaluate_notebook(self.absolute_path_python('65_Registration_FFD.ipynb'), 'python3')
+
+    def test_66_Registration_Demons_p(self):
+        self.evaluate_notebook(self.absolute_path_python('66_Registration_Demons.ipynb'), 'python3')
+
+    def test_67_Registration_Semiautomatic_Homework_p(self):
+        self.evaluate_notebook(self.absolute_path_python('67_Registration_Semiautomatic_Homework.ipynb'), 'python3')
+
+    #
+    # R notebook testing.
+    #
+
+    def test_Image_Basics_r(self):
+        self.evaluate_notebook(self.absolute_path_r('Image_Basics.ipynb'), 'ir')
+
+    def test_R_style_image_r(self):
+        self.evaluate_notebook(self.absolute_path_r('R_style_image.ipynb'), 'ir')
+
+    def test_33_Segmentation_Thresholding_Edge_Detection_r(self):
+        self.evaluate_notebook(self.absolute_path_r('33_Segmentation_Thresholding_Edge_Detection.ipynb'), 'ir')
+
+
+
+


### PR DESCRIPTION
Adding a testing framework to improve maintainability of the
notebook repository. The testing code relies on the pytest package. We
deal with three types of errors:
1. Unexpected errors - something is broken in our code.
2. Allowed errors - errors that may or may not occur, such as calling
sitk.Show() when Fiji/ImageJ is not installed.
3. Expected errors - errors that should occur. These are errors we
intentionally introduced to illustrate a concept.

The latter two are marked in the metadata of the cell that generates
the error. For specifics see the test_notebooks.py script.