### PR TITLE
Replaced calls to GetPixelIDValue with GetPixelID.

### DIFF
--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -787,7 +787,7 @@
     "\n",
     "# Why is the image pixelated?\n",
     "sitk_isotropic_xslice = resampleSliceFilter.Execute(sitk_xslice, new_size, sitk.Transform(), sitk.sitkNearestNeighbor, sitk_xslice.GetOrigin(),\n",
-    "                                                    new_spacing, sitk_xslice.GetDirection(), 0, sitk_xslice.GetPixelIDValue())\n",
+    "                                                    new_spacing, sitk_xslice.GetDirection(), 0, sitk_xslice.GetPixelID())\n",
     "\n",
     "plt.imshow(sitk.GetArrayFromImage(sitk_isotropic_xslice), cmap=plt.cm.Greys_r)\n",
     "plt.axis('off')\n",

--- a/Python/10_matplotlib's_imshow.ipynb
+++ b/Python/10_matplotlib's_imshow.ipynb
@@ -368,7 +368,7 @@
     "    maxlen = max(len(img_xslices), len(img_yslices), len(img_zslices))\n",
     "    \n",
     "        \n",
-    "    img_null = sitk.Image([0,0], img.GetPixelIDValue(), img.GetNumberOfComponentsPerPixel())\n",
+    "    img_null = sitk.Image([0,0], img.GetPixelID(), img.GetNumberOfComponentsPerPixel())\n",
     "    \n",
     "    img_slices = []\n",
     "    d = 0\n",
@@ -472,7 +472,7 @@
    "source": [
     "# Option 1: Resample the label image using the identity transformation\n",
     "resampled_img_labels = sitk.Resample(img_labels, img_T1, sitk.Transform(), sitk.sitkNearestNeighbor,\n",
-    "                                     0.0, img_labels.GetPixelIDValue())\n",
+    "                                     0.0, img_labels.GetPixelID())\n",
     "# Overlay onto the T1 image, requires us to rescale the intensity of the T1 image to [0,255] and cast it so that it can \n",
     "# be combined with the color overlay (we use an alpha blending of 0.5).\n",
     "myshow3d(sitk.LabelOverlay(sitk.Cast(sitk.RescaleIntensity(img_T1), sitk.sitkUInt8),resampled_img_labels, 0.5),\n",
@@ -489,7 +489,7 @@
    "source": [
     "# Option 2: Resample the T1 image using the identity transformation\n",
     "resampled_T1 = sitk.Resample(img_T1, img_labels, sitk.Transform(), sitk.sitkLinear,\n",
-    "                             0.0, img_T1.GetPixelIDValue())\n",
+    "                             0.0, img_T1.GetPixelID())\n",
     "# Overlay onto the T1 image, requires us to rescale the intensity of the T1 image to [0,255] and cast it so that it can \n",
     "# be combined with the color overlay (we use an alpha blending of 0.5).\n",
     "myshow3d(sitk.LabelOverlay(sitk.Cast(sitk.RescaleIntensity(resampled_T1), sitk.sitkUInt8),img_labels, 0.5),\n",

--- a/Python/56_VH_Registration1.ipynb
+++ b/Python/56_VH_Registration1.ipynb
@@ -124,7 +124,7 @@
    "outputs": [],
    "source": [
     "initialTransform = sitk.Euler3DTransform()\n",
-    "initialTransform = sitk.CenteredTransformInitializer(sitk.Cast(fixed_mask,moving.GetPixelIDValue()), moving, initialTransform, sitk.CenteredTransformInitializerFilter.MOMENTS)\n",
+    "initialTransform = sitk.CenteredTransformInitializer(sitk.Cast(fixed_mask,moving.GetPixelID()), moving, initialTransform, sitk.CenteredTransformInitializerFilter.MOMENTS)\n",
     "print(initialTransform)"
    ]
   },

--- a/Python/60_Registration_Introduction.ipynb
+++ b/Python/60_Registration_Introduction.ipynb
@@ -259,7 +259,7 @@
     "                                                      sitk.Euler3DTransform(), \n",
     "                                                      sitk.CenteredTransformInitializerFilter.GEOMETRY)\n",
     "\n",
-    "moving_resampled = sitk.Resample(moving_image, fixed_image, initial_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelIDValue())\n",
+    "moving_resampled = sitk.Resample(moving_image, fixed_image, initial_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelID())\n",
     "\n",
     "interact(display_images_with_alpha, image_z=(0,fixed_image.GetSize()[2]), alpha=(0.0,1.0,0.05), fixed = fixed(fixed_image), moving=fixed(moving_resampled));"
    ]
@@ -383,7 +383,7 @@
    },
    "outputs": [],
    "source": [
-    "moving_resampled = sitk.Resample(moving_image, fixed_image, final_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelIDValue())\n",
+    "moving_resampled = sitk.Resample(moving_image, fixed_image, final_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelID())\n",
     "\n",
     "interact(display_images_with_alpha, image_z=(0,fixed_image.GetSize()[2]), alpha=(0.0,1.0,0.05), fixed = fixed(fixed_image), moving=fixed(moving_resampled));"
    ]

--- a/Python/61_Registration_Introduction_Continued.ipynb
+++ b/Python/61_Registration_Introduction_Continued.ipynb
@@ -216,7 +216,7 @@
    },
    "outputs": [],
    "source": [
-    "initial_transform = sitk.CenteredTransformInitializer(sitk.Cast(fixed_image,moving_image.GetPixelIDValue()), \n",
+    "initial_transform = sitk.CenteredTransformInitializer(sitk.Cast(fixed_image,moving_image.GetPixelID()), \n",
     "                                                      moving_image, \n",
     "                                                      sitk.Euler3DTransform(), \n",
     "                                                      sitk.CenteredTransformInitializerFilter.GEOMETRY)\n",

--- a/Python/62_Registration_Tuning.ipynb
+++ b/Python/62_Registration_Tuning.ipynb
@@ -101,7 +101,7 @@
    },
    "outputs": [],
    "source": [
-    "initial_transform = sitk.CenteredTransformInitializer(sitk.Cast(fixed_image,moving_image.GetPixelIDValue()), \n",
+    "initial_transform = sitk.CenteredTransformInitializer(sitk.Cast(fixed_image,moving_image.GetPixelID()), \n",
     "                                                      moving_image, \n",
     "                                                      sitk.Euler3DTransform(), \n",
     "                                                      sitk.CenteredTransformInitializerFilter.GEOMETRY)\n",

--- a/Python/63_Registration_Initialization.ipynb
+++ b/Python/63_Registration_Initialization.ipynb
@@ -220,7 +220,7 @@
    },
    "outputs": [],
    "source": [
-    "moving_resampled = sitk.Resample(modified_moving_image, fixed_image, final_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelIDValue())\n",
+    "moving_resampled = sitk.Resample(modified_moving_image, fixed_image, final_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelID())\n",
     "\n",
     "interact(ru.display_images_with_alpha, image_z=(0,fixed_image.GetSize()[2]), alpha=(0.0,1.0,0.05), \n",
     "         image1 = fixed(sitk.IntensityWindowing(fixed_image, fixed_intensity_range[0], fixed_intensity_range[1])), \n",
@@ -316,7 +316,7 @@
    },
    "outputs": [],
    "source": [
-    "moving_resampled = sitk.Resample(modified_moving_image, fixed_image, final_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelIDValue())\n",
+    "moving_resampled = sitk.Resample(modified_moving_image, fixed_image, final_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelID())\n",
     "\n",
     "interact(ru.display_images_with_alpha, image_z=(0,fixed_image.GetSize()[2]), alpha=(0.0,1.0,0.05), \n",
     "         image1 = fixed(sitk.IntensityWindowing(fixed_image, fixed_intensity_range[0], fixed_intensity_range[1])), \n",
@@ -383,7 +383,7 @@
    },
    "outputs": [],
    "source": [
-    "moving_resampled = sitk.Resample(modified_moving_image, fixed_image, final_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelIDValue())\n",
+    "moving_resampled = sitk.Resample(modified_moving_image, fixed_image, final_transform, sitk.sitkLinear, 0.0, moving_image.GetPixelID())\n",
     "\n",
     "interact(ru.display_images_with_alpha, image_z=(0,fixed_image.GetSize()[2]), alpha=(0.0,1.0,0.05), \n",
     "         image1 = fixed(sitk.IntensityWindowing(fixed_image, fixed_intensity_range[0], fixed_intensity_range[1])), \n",

--- a/Python/64_Registration_Memory_Time_Tradeoff.ipynb
+++ b/Python/64_Registration_Memory_Time_Tradeoff.ipynb
@@ -138,7 +138,7 @@
     "original_spacing = moving_image.GetSpacing()\n",
     "resampled_image_size = [int(spacing/new_s*size) \n",
     "                        for spacing, size, new_s in zip(original_spacing, original_size, new_spacing)]  \n",
-    "resampled_moving_image = sitk.Image(resampled_image_size, moving_image.GetPixelIDValue())\n",
+    "resampled_moving_image = sitk.Image(resampled_image_size, moving_image.GetPixelID())\n",
     "resampled_moving_image.SetSpacing(new_spacing)\n",
     "resampled_moving_image.SetOrigin(moving_image.GetOrigin())\n",
     "resampled_moving_image.SetDirection(moving_image.GetDirection())\n",

--- a/Python/65_Registration_FFD.ipynb
+++ b/Python/65_Registration_FFD.ipynb
@@ -253,7 +253,7 @@
     "                                   tx, \n",
     "                                   sitk.sitkNearestNeighbor,\n",
     "                                   0.0, \n",
-    "                                   masks[moving_image_index].GetPixelIDValue())\n",
+    "                                   masks[moving_image_index].GetPixelID())\n",
     "\n",
     "segmentations_before_and_after = [masks[moving_image_index], transformed_labels]\n",
     "interact(display_coronal_with_label_maps_overlay, coronal_slice = (0, images[0].GetSize()[1]-1),\n",

--- a/Python/66_Registration_Demons.ipynb
+++ b/Python/66_Registration_Demons.ipynb
@@ -236,7 +236,7 @@
     "    return sitk.Resample(smoothed_image, new_size, sitk.Transform(), \n",
     "                         sitk.sitkLinear, image.GetOrigin(),\n",
     "                         new_spacing, image.GetDirection(), 0.0, \n",
-    "                         image.GetPixelIDValue())\n",
+    "                         image.GetPixelID())\n",
     "\n",
     "\n",
     "    \n",

--- a/Python/myshow.py
+++ b/Python/myshow.py
@@ -73,7 +73,7 @@ def myshow3d(img, xslices=[], yslices=[], zslices=[], title=None, margin=0.05, d
     maxlen = max(len(img_xslices), len(img_yslices), len(img_zslices))
 
 
-    img_null = sitk.Image([0,0], img.GetPixelIDValue(), img.GetNumberOfComponentsPerPixel())
+    img_null = sitk.Image([0,0], img.GetPixelID(), img.GetNumberOfComponentsPerPixel())
 
     img_slices = []
     d = 0

--- a/Python/popi_utilities_setup.py
+++ b/Python/popi_utilities_setup.py
@@ -45,11 +45,11 @@ def overlay_binary_segmentation_contours(image, mask, window_min, window_max):
     resampled_img = sitk.Resample(image, new_size, sitk.Transform(), 
                                   sitk.sitkLinear, image.GetOrigin(),
                                   new_spacing, image.GetDirection(), 0.0, 
-                                  image.GetPixelIDValue())
+                                  image.GetPixelID())
     resampled_msk = sitk.Resample(mask, new_size, sitk.Transform(), 
                                   sitk.sitkNearestNeighbor, mask.GetOrigin(),
                                   new_spacing, mask.GetDirection(), 0.0, 
-                                  mask.GetPixelIDValue())
+                                  mask.GetPixelID())
 
     # Create the overlay: cast the mask to expected label pixel type, and do the same for the image after
     # window-level, accounting for the high dynamic range of the CT.


### PR DESCRIPTION
The GetPixelIDValue returns the internal value of the enumerated type
returned by GetPixelID. The correct approach is to use the enumerated
type (in R GetPixelID will return a string, the enumerated
type, and GetPixelIDValue will return the integer value).