### PR TITLE
Modify the code to use GetArrayViewFromImage().

### DIFF
--- a/Python/01_Image_Basics.ipynb
+++ b/Python/01_Image_Basics.ipynb
@@ -327,6 +327,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Get a view of the image data as a numpy array, useful for display\n",
+    "nda = sitk.GetArrayViewFromImage(image)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "collapsed": false
    },
    "outputs": [],
@@ -444,18 +456,9 @@
    "outputs": [],
    "source": [
     "z = 0\n",
-    "slice = sitk.GetArrayFromImage(image)[z,:,:]\n",
+    "slice = sitk.GetArrayViewFromImage(image)[z,:,:]\n",
     "plt.imshow(slice)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/02_Pythonic_Image.ipynb
+++ b/Python/02_Pythonic_Image.ipynb
@@ -45,7 +45,7 @@
    "outputs": [],
    "source": [
     "img = sitk.GaussianSource(size=[64]*2)\n",
-    "plt.imshow(sitk.GetArrayFromImage(img))"
+    "plt.imshow(sitk.GetArrayViewFromImage(img))"
    ]
   },
   {
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "img = sitk.GaborSource(size=[64]*2, frequency=.03)\n",
-    "plt.imshow(sitk.GetArrayFromImage(img))"
+    "plt.imshow(sitk.GetArrayViewFromImage(img))"
    ]
   },
   {
@@ -69,7 +69,7 @@
    "outputs": [],
    "source": [
     "def myshow(img):\n",
-    "    nda = sitk.GetArrayFromImage(img)\n",
+    "    nda = sitk.GetArrayViewFromImage(img)\n",
     "    plt.imshow(nda)\n",
     "myshow(img)"
    ]

--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -103,7 +103,7 @@
    "source": [
     "logo = sitk.ReadImage(fdata('SimpleITK.jpg'))\n",
     "\n",
-    "plt.imshow(sitk.GetArrayFromImage(logo))\n",
+    "plt.imshow(sitk.GetArrayViewFromImage(logo))\n",
     "plt.axis('off');"
    ]
   },
@@ -314,19 +314,19 @@
     "n = 4\n",
     "\n",
     "plt.subplot(n,1,1)\n",
-    "plt.imshow(sitk.GetArrayFromImage(logo))\n",
+    "plt.imshow(sitk.GetArrayViewFromImage(logo))\n",
     "plt.axis('off');\n",
     "\n",
     "plt.subplot(n,1,2)\n",
-    "plt.imshow(sitk.GetArrayFromImage(logo_subsampled))\n",
+    "plt.imshow(sitk.GetArrayViewFromImage(logo_subsampled))\n",
     "plt.axis('off');\n",
     "\n",
     "plt.subplot(n,1,3)\n",
-    "plt.imshow(sitk.GetArrayFromImage(simple))\n",
+    "plt.imshow(sitk.GetArrayViewFromImage(simple))\n",
     "plt.axis('off')\n",
     "\n",
     "plt.subplot(n,1,4)\n",
-    "plt.imshow(sitk.GetArrayFromImage(simple_flipped))\n",
+    "plt.imshow(sitk.GetArrayViewFromImage(simple_flipped))\n",
     "plt.axis('off');"
    ]
   },
@@ -368,7 +368,7 @@
     "\n",
     "        \n",
     "plt.subplot(2,1,1)\n",
-    "plt.imshow(sitk.GetArrayFromImage(logo))\n",
+    "plt.imshow(sitk.GetArrayViewFromImage(logo))\n",
     "plt.axis('off')\n",
     "\n",
     "plt.subplot(2,1,2)\n",
@@ -392,7 +392,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### From SimpleITK to numpy"
+    "### From SimpleITK to numpy\n",
+    "\n",
+    "We have two options for converting from SimpleITK to numpy:\n",
+    "* GetArrayFromImage(): returns a copy of the image data. You can then freely modify the data as it has no effect on the original SimpleITK image.\n",
+    "* GetArrayViewFromImage(): returns a view on the image data which is useful for display in a memory efficient manner. You cannot modify the data and __the view will be invalid if the original SimpleITK image is deleted__."
    ]
   },
   {
@@ -410,6 +414,25 @@
     "nda = sitk.GetArrayFromImage(image_RGB)\n",
     "print(image_RGB.GetSize())\n",
     "print(nda.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "simpleitk_error_expected": "assignment destination is read-only"
+   },
+   "outputs": [],
+   "source": [
+    "gabor_image = sitk.GaborSource(size=[64,64], frequency=.03)\n",
+    "# Getting a numpy array view on the image data doesn't copy the data\n",
+    "nda_view = sitk.GetArrayViewFromImage(gabor_image)\n",
+    "plt.imshow(nda_view, cmap=plt.cm.Greys_r)\n",
+    "plt.axis('off');\n",
+    "\n",
+    "# Trying to assign a value to the array view will throw an exception\n",
+    "nda_view[0,0] = 255"
    ]
   },
   {
@@ -537,7 +560,7 @@
     "    \n",
     "    print(img.GetPixelIDTypeAsString())\n",
     "    print(img[0,0])\n",
-    "    plt.imshow(sitk.GetArrayFromImage(img))\n",
+    "    plt.imshow(sitk.GetArrayViewFromImage(img))\n",
     "    plt.axis('off')\n",
     " \n",
     "interact(pixel_type_dropdown_callback, pixel_type=list(pixel_types.keys()), pixel_types_dict=fixed(pixel_types));     "
@@ -660,10 +683,9 @@
    "source": [
     "reader.SetFileNames(series_file_names[selected_series])\n",
     "img = reader.Execute()\n",
-    "npa = sitk.GetArrayFromImage(img)\n",
     "# Display the image slice from the middle of the stack, z axis\n",
     "z = int(img.GetDepth()/2)\n",
-    "plt.imshow(sitk.GetArrayFromImage(img)[z,:,:], cmap=plt.cm.Greys_r)\n",
+    "plt.imshow(sitk.GetArrayViewFromImage(img)[z,:,:], cmap=plt.cm.Greys_r)\n",
     "plt.axis('off');"
    ]
   },
@@ -712,11 +734,11 @@
    "outputs": [],
    "source": [
     "mr_image = sitk.ReadImage(fdata('training_001_mr_T1.mha'))\n",
-    "npa = sitk.GetArrayFromImage(mr_image)\n",
+    "npa = sitk.GetArrayViewFromImage(mr_image)\n",
     "\n",
     "# Display the image slice from the middle of the stack, z axis\n",
     "z = int(mr_image.GetDepth()/2)\n",
-    "npa_zslice = sitk.GetArrayFromImage(mr_image)[z,:,:]\n",
+    "npa_zslice = sitk.GetArrayViewFromImage(mr_image)[z,:,:]\n",
     "\n",
     "# Three plots displaying the same data, how do we deal with the high dynamic range?\n",
     "fig = plt.figure()\n",
@@ -789,7 +811,7 @@
     "sitk_isotropic_xslice = resampleSliceFilter.Execute(sitk_xslice, new_size, sitk.Transform(), sitk.sitkNearestNeighbor, sitk_xslice.GetOrigin(),\n",
     "                                                    new_spacing, sitk_xslice.GetDirection(), 0, sitk_xslice.GetPixelID())\n",
     "\n",
-    "plt.imshow(sitk.GetArrayFromImage(sitk_isotropic_xslice), cmap=plt.cm.Greys_r)\n",
+    "plt.imshow(sitk.GetArrayViewFromImage(sitk_isotropic_xslice), cmap=plt.cm.Greys_r)\n",
     "plt.axis('off')\n",
     "print('Image spacing: {0}'.format(sitk_isotropic_xslice.GetSpacing()))"
    ]
@@ -890,7 +912,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.5"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/Python/10_matplotlib's_imshow.ipynb
+++ b/Python/10_matplotlib's_imshow.ipynb
@@ -68,7 +68,7 @@
    },
    "outputs": [],
    "source": [
-    "nda = sitk.GetArrayFromImage(img1)\n",
+    "nda = sitk.GetArrayViewFromImage(img1)\n",
     "plt.imshow(nda)"
    ]
   },
@@ -80,7 +80,7 @@
    },
    "outputs": [],
    "source": [
-    "nda = sitk.GetArrayFromImage(img2)\n",
+    "nda = sitk.GetArrayViewFromImage(img2)\n",
     "ax = plt.imshow(nda)"
    ]
   },
@@ -93,7 +93,7 @@
    "outputs": [],
    "source": [
     "def myshow(img):\n",
-    "    nda = sitk.GetArrayFromImage(img)\n",
+    "    nda = sitk.GetArrayViewFromImage(img)\n",
     "    plt.imshow(nda)"
    ]
   },
@@ -142,7 +142,7 @@
    "outputs": [],
    "source": [
     "def myshow(img, title=None, margin=0.05, dpi=80):\n",
-    "    nda = sitk.GetArrayFromImage(img)\n",
+    "    nda = sitk.GetArrayViewFromImage(img)\n",
     "    spacing = img.GetSpacing()\n",
     "        \n",
     "    if nda.ndim == 3:\n",

--- a/Python/20_Expand_With_Interpolators.ipynb
+++ b/Python/20_Expand_With_Interpolators.ipynb
@@ -40,7 +40,7 @@
     "                          img[:,:,img.GetSize()[2]//2]), [2,2])\n",
     "            \n",
     "    \n",
-    "    aimg = sitk.GetArrayFromImage(img)\n",
+    "    aimg = sitk.GetArrayViewFromImage(img)\n",
     "    \n",
     "    xsize,ysize = aimg.shape\n",
     "\n",

--- a/Python/21_Transforms_and_Resampling.ipynb
+++ b/Python/21_Transforms_and_Resampling.ipynb
@@ -155,7 +155,7 @@
    "outputs": [],
    "source": [
     "def myshow(img, title=None, margin=0.05, dpi=80):\n",
-    "    nda = sitk.GetArrayFromImage(img)\n",
+    "    nda = sitk.GetArrayViewFromImage(img)\n",
     "    spacing = img.GetSpacing()\n",
     "        \n",
     "    ysize = nda.shape[0]\n",

--- a/Python/33_Segmentation_Thresholding_Edge_Detection.ipynb
+++ b/Python/33_Segmentation_Thresholding_Edge_Detection.ipynb
@@ -126,7 +126,7 @@
    },
    "outputs": [],
    "source": [
-    "intensity_values = sitk.GetArrayFromImage(spherical_fiducials_image)\n",
+    "intensity_values = sitk.GetArrayViewFromImage(spherical_fiducials_image)\n",
     "roi_intensity_values = intensity_values[roi[2][0]:roi[2][1],\n",
     "                                        roi[1][0]:roi[1][1],\n",
     "                                        roi[0][0]:roi[0][1]].flatten()\n",
@@ -254,7 +254,7 @@
    },
    "outputs": [],
    "source": [
-    "edge_indexes = np.where(sitk.GetArrayFromImage(edges) == 1.0)\n",
+    "edge_indexes = np.where(sitk.GetArrayViewFromImage(edges) == 1.0)\n",
     "\n",
     "# Note the reversed order of access between SimpleITK and numpy (z,y,x)\n",
     "physical_points = [edges.TransformIndexToPhysicalPoint([int(x), int(y), int(z)]) \\\n",
@@ -328,7 +328,7 @@
   },
   "widgets": {
    "state": {
-    "38f2301f0b8d451e809bf4799b06eaa4": {
+    "d38f7d8b382143729dd4b1623212cfab": {
      "views": [
       {
        "cell_index": 5

--- a/Python/34_Segmentation_Evaluation.ipynb
+++ b/Python/34_Segmentation_Evaluation.ipynb
@@ -77,7 +77,7 @@
     "                                             opacity = 1, \n",
     "                                             contourThickness=[2,2])\n",
     "    #We assume the original slice is isotropic, otherwise the display would be distorted \n",
-    "    plt.imshow(sitk.GetArrayFromImage(overlay_img))\n",
+    "    plt.imshow(sitk.GetArrayViewFromImage(overlay_img))\n",
     "    plt.axis('off')\n",
     "    plt.show()"
    ]

--- a/Python/60_Registration_Introduction.ipynb
+++ b/Python/60_Registration_Introduction.ipynb
@@ -173,7 +173,7 @@
     "# of an image stack of two images that occupy the same physical space. \n",
     "def display_images_with_alpha(image_z, alpha, fixed, moving):\n",
     "    img = (1.0 - alpha)*fixed[:,:,image_z] + alpha*moving[:,:,image_z] \n",
-    "    plt.imshow(sitk.GetArrayFromImage(img),cmap=plt.cm.Greys_r);\n",
+    "    plt.imshow(sitk.GetArrayViewFromImage(img),cmap=plt.cm.Greys_r);\n",
     "    plt.axis('off')\n",
     "    plt.show()\n",
     "    \n",
@@ -234,7 +234,7 @@
     "fixed_image =  sitk.ReadImage(fdata(\"training_001_ct.mha\"), sitk.sitkFloat32)\n",
     "moving_image = sitk.ReadImage(fdata(\"training_001_mr_T1.mha\"), sitk.sitkFloat32) \n",
     "\n",
-    "interact(display_images, fixed_image_z=(0,fixed_image.GetSize()[2]-1), moving_image_z=(0,moving_image.GetSize()[2]-1), fixed_npa = fixed(sitk.GetArrayFromImage(fixed_image)), moving_npa=fixed(sitk.GetArrayFromImage(moving_image)));"
+    "interact(display_images, fixed_image_z=(0,fixed_image.GetSize()[2]-1), moving_image_z=(0,moving_image.GetSize()[2]-1), fixed_npa = fixed(sitk.GetArrayViewFromImage(fixed_image)), moving_npa=fixed(sitk.GetArrayViewFromImage(moving_image)));"
    ]
   },
   {

--- a/Python/environment.yml
+++ b/Python/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - numpy
   - scipy
   - pandas
-  - SimpleITK>=0.10.0
+  - SimpleITK>=1.0.0

--- a/Python/gui.py
+++ b/Python/gui.py
@@ -93,7 +93,7 @@ class RegistrationPointDataAquisition(object):
         Get the numpy array representation of the image and the min and max of the intensities
         used for display.
         """
-        npa = sitk.GetArrayFromImage(image)
+        npa = sitk.GetArrayViewFromImage(image)
         if not window_level:
             return npa, npa.min(), npa.max()
         else:
@@ -283,7 +283,7 @@ class PointDataAquisition(object):
         return widgets.HBox(children=[widgets.HBox(children=[bx1, bx2, bx3]),bx0])
         
     def get_window_level_numpy_array(self, image, window_level):
-        npa = sitk.GetArrayFromImage(image)
+        npa = sitk.GetArrayViewFromImage(image)
         if not window_level:
             return npa, npa.min(), npa.max()
         else:
@@ -441,6 +441,9 @@ class MultiImageDisplay(object):
         return ui
 
     def get_window_level_numpy_array(self, image_list, window_level_list):
+        # Using GetArray and not GetArrayView because we don't keep references
+        # to the original images. If they are deleted outside the view would become
+        # invalid, so we use a copy wich guarentees that the gui is consistent.
         self.npa_list = list(map(sitk.GetArrayFromImage, image_list))
         if not window_level_list:
             self.min_intensity_list = list(map(np.min, self.npa_list))
@@ -569,7 +572,7 @@ class ROIDataAquisition(object):
 
 
     def get_window_level_numpy_array(self, image, window_level):
-        npa = sitk.GetArrayFromImage(image)
+        npa = sitk.GetArrayViewFromImage(image)
         # We don't take the minimum/maximum values, just in case there are outliers (top/bottom 2%)
         if not window_level:
             min_max = np.percentile(npa.flatten(), [2,98])

--- a/Python/myshow.py
+++ b/Python/myshow.py
@@ -5,7 +5,7 @@ from ipywidgets import interact, interactive
 from ipywidgets import widgets
 
 def myshow(img, title=None, margin=0.05, dpi=80 ):
-    nda = sitk.GetArrayFromImage(img)
+    nda = sitk.GetArrayViewFromImage(img)
 
     spacing = img.GetSpacing()
     slicer = False

--- a/Python/popi_utilities_setup.py
+++ b/Python/popi_utilities_setup.py
@@ -71,7 +71,7 @@ def display_coronal_with_overlay(temporal_slice, coronal_slice, images, masks, l
 
     overlay_img = overlay_binary_segmentation_contours(img, msk, window_min, window_max)    
     # Flip the image so that corresponds to correct radiological view.
-    plt.imshow(np.flipud(sitk.GetArrayFromImage(overlay_img)))
+    plt.imshow(np.flipud(sitk.GetArrayViewFromImage(overlay_img)))
     plt.axis('off')
     plt.show()
 
@@ -86,6 +86,6 @@ def display_coronal_with_label_maps_overlay(coronal_slice, mask_index, image, ma
 
     overlay_img = overlay_binary_segmentation_contours(img, msk, window_min, window_max)
     # Flip the image so that corresponds to correct radiological view.
-    plt.imshow(np.flipud(sitk.GetArrayFromImage(overlay_img)))
+    plt.imshow(np.flipud(sitk.GetArrayViewFromImage(overlay_img)))
     plt.axis('off')
     plt.show()

--- a/Python/registration_utilities.py
+++ b/Python/registration_utilities.py
@@ -199,12 +199,12 @@ def display_scalar_images(image1_z_index, image2_z_index, image1, image2,
     plt.subplots(1,2,figsize=figure_size)
     
     plt.subplot(1,2,1)
-    plt.imshow(sitk.GetArrayFromImage(image1[:,:,image1_z_index]),cmap=plt.cm.Greys_r, vmin=vmin1, vmax=vmax1)
+    plt.imshow(sitk.GetArrayViewFromImage(image1[:,:,image1_z_index]),cmap=plt.cm.Greys_r, vmin=vmin1, vmax=vmax1)
     plt.title(title1)
     plt.axis('off')
     
     plt.subplot(1,2,2)
-    plt.imshow(sitk.GetArrayFromImage(image2[:,:,image2_z_index]),cmap=plt.cm.Greys_r, vmin=vmin2, vmax=vmax2)
+    plt.imshow(sitk.GetArrayViewFromImage(image2[:,:,image2_z_index]),cmap=plt.cm.Greys_r, vmin=vmin2, vmax=vmax2)
     plt.title(title2)
     plt.axis('off')
 
@@ -218,6 +218,6 @@ def display_images_with_alpha(image_z, alpha, image1, image2):
     spacing, direction, size), if they do not, an exception is thrown.
     """
     img = (1.0 - alpha)*image1[:,:,image_z] + alpha*image2[:,:,image_z] 
-    plt.imshow(sitk.GetArrayFromImage(img),cmap=plt.cm.Greys_r);
+    plt.imshow(sitk.GetArrayViewFromImage(img),cmap=plt.cm.Greys_r);
     plt.axis('off')
     plt.show()

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,4 +1,4 @@
-SimpleITK>=0.10.0
+SimpleITK>=1.0.0
 jupyter
 matplotlib
 ipywidgets

--- a/tests/additional_dictionary.txt
+++ b/tests/additional_dictionary.txt
@@ -264,4 +264,6 @@ resamples
 ReadImage
 ROIs
 toolbar
+GetArrayFromImage
+GetArrayViewFromImage
 


### PR DESCRIPTION
Previously we used the GetArrayFromImage function to get the numpy
array for display purposes. This created a copy of the image data. We
now use the GetArrayViewFromImage function which only returns the view
so that the data is not copied.