### PR TITLE
Fixed html table markup.

### DIFF
--- a/Python/02_Pythonic_Image.ipynb
+++ b/Python/02_Pythonic_Image.ipynb
@@ -268,7 +268,7 @@
     "    <tr><td>/</td></tr>\n",
     "    <tr><td>//</td></tr>\n",
     "    <tr><td>**</td></tr>\n",
-    "<table>\n"
+    "</table>\n"
    ]
   },
   {
@@ -323,7 +323,7 @@
     "    <tr><td>|</td></tr>\n",
     "    <tr><td>^</td></tr>\n",
     "    <tr><td>~</td></tr>\n",
-    "<table>"
+    "</table>"
    ]
   },
   {
@@ -350,7 +350,7 @@
     "    <tr><td>&lt;</td></tr>\n",
     "    <tr><td>&lt;=</td></tr>\n",
     "    <tr><td>==</td></tr>\n",
-    "<table>\n",
+    "</table>\n",
     "\n",
     "These comparative operators follow the same convention as the reset of SimpleITK for binary images. They have the pixel type of ``sitkUInt8`` with values of 0 and 1. \n",
     "    "


### PR DESCRIPTION
The closing table markup was missing a slash. This didn't effect the
display of the notebook, but caused problems when saved to html.