### PR TITLE
BUG: Empty title list for MultiImageDisplay was not handled correctly.

### DIFF
--- a/Python/gui.py
+++ b/Python/gui.py
@@ -381,6 +381,8 @@ class MultiImageDisplay(object):
             if len(image_list)!=len(title_list):
                 raise ValueError('Title list and image list lengths do not match')
             self.title_list = list(title_list)
+        else:
+            self.title_list = ['']*len(image_list)
 
         # Our dynamic slice, based on the axis the user specifies
         self.slc = [slice(None)]*3


### PR DESCRIPTION
When no title list is given, create a list with empty
titles. Previously this class variable was not set resulting in a
runtime exception.