### PR TITLE
Removing symbolic link from root directory.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,1 +1,0 @@
-Python/environment.yml


### PR DESCRIPTION
The original intent was to take advantage of the free computing
resources provided by the binder project (mybinder.org) to allow users
to run the notebooks without installation. The service was not too
reliable and the use of a symbolic link causes potential problems on
the Windows operating system. When the repository is cloned on windows
the soft link is replaced with a file having the same name which
contains the path to the actual file (i.e. "Python/environment.yml").
When users try to install the environment using this file, conda will
fail as the content is not a valid description of an environment.