### PR TITLE
BUG: segfault during display when using GetArrayViewFromImage.

### DIFF
--- a/Python/myshow.py
+++ b/Python/myshow.py
@@ -5,7 +5,7 @@ from ipywidgets import interact, interactive
 from ipywidgets import widgets
 
 def myshow(img, title=None, margin=0.05, dpi=80 ):
-    nda = sitk.GetArrayViewFromImage(img)
+    nda = sitk.GetArrayFromImage(img)
 
     spacing = img.GetSpacing()
     slicer = False


### PR DESCRIPTION
The use of the numpy array from GetArrayViewFromImage is valid as long as the
SimpleITK image object hasn't been deleted. In the case of the myshow
function this is not necessarily true, so we revert to the
GetArrayFromImage function.

The bug in myshow/myshow3d was reported by Elvis Chen
(Robarts Research Institute).