### PR TITLE
Updating data augmentation notebook.

### DIFF
--- a/Python/70_Data_Augmentation.ipynb
+++ b/Python/70_Data_Augmentation.ipynb
@@ -52,7 +52,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
    },
    "outputs": [],
@@ -73,7 +72,7 @@
     "sitk.Show(sitk.Resample(grid_image, reference_image) , \"resampled without smoothing\")\n",
     "\n",
     "# Resample after Gaussian smoothing.\n",
-    "sitk.Show(sitk.Resample(sitk.SmoothingRecursiveGaussian(grid_image, sigma=2.0), reference_image), \"resampled with smoothing\")"
+    "sitk.Show(sitk.Resample(sitk.SmoothingRecursiveGaussian(grid_image, 2.0), reference_image), \"resampled with smoothing\")"
    ]
   },
   {
@@ -88,9 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data = [sitk.ReadImage(fdata(\"nac-hncma-atlas2013-Slicer4Version/Data/A1_grayT1.nrrd\")),\n",
@@ -105,7 +102,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
@@ -129,14 +125,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def threshold_based_crop(image):\n",
-    "    '''\n",
-    "    '''\n",
+    "    \"\"\"\n",
+    "    Use Otsu's threshold estimator to separate background and foreground. In medical imaging the background is\n",
+    "    usually air. Then crop the image using the foreground's axis aligned bounding box.\n",
+    "    Args:\n",
+    "        image (SimpleITK image): An image where the anatomy and background intensities form a bi-modal distribution\n",
+    "                                 (the assumption underlying Otsu's method.)\n",
+    "    Return:\n",
+    "        Cropped image based on foreground's axis aligned bounding box.                                 \n",
+    "    \"\"\"\n",
     "    # Set pixels that are in [min_intensity,otsu_threshold] to inside_value, values above otsu_threshold are\n",
     "    # set to outside_value. The anatomy has higher intensity values than the background, so it is outside.\n",
     "    inside_value = 0\n",
@@ -196,9 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def parameter_space_regular_grid_sampling(*transformation_parameters):\n",
@@ -302,9 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dimension = data[0].GetDimension()\n",
@@ -317,8 +314,20 @@
     "# Create the reference image with a zero origin, identity direction cosine matrix and dimension     \n",
     "reference_origin = np.zeros(dimension)\n",
     "reference_direction = np.identity(dimension).flatten()\n",
-    "reference_size = [128]*dimension # Arbitrary sizes, smallest size that yields desired results. \n",
+    "\n",
+    "# Select arbitrary number of pixels per dimension, smallest size that yields desired results \n",
+    "# or the required size of a pretrained network (e.g. VGG-16 224x224), transfer learning. This will \n",
+    "# often result in non-isotropic pixel spacing.\n",
+    "reference_size = [128]*dimension \n",
     "reference_spacing = [ phys_sz/(sz-1) for sz,phys_sz in zip(reference_size, reference_physical_size) ]\n",
+    "\n",
+    "# Another possibility is that you want isotropic pixels, then you can specify the image size for one of\n",
+    "# the axes and the others are determined by this choice. Below we choose to set the x axis to 128 and the\n",
+    "# spacing set accordingly. \n",
+    "# Uncomment the following lines to use this strategy.\n",
+    "#reference_size_x = 128\n",
+    "#reference_spacing = [reference_physical_size[0]/(reference_size_x-1)]*dimension\n",
+    "#reference_size = [int(phys_sz/(spc) + 1) for phys_sz,spc in zip(reference_physical_size, reference_spacing)]\n",
     "\n",
     "reference_image = sitk.Image(reference_size, data[0].GetPixelIDValue())\n",
     "reference_image.SetOrigin(reference_origin)\n",
@@ -346,9 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def augment_images_spatial(original_image, reference_image, T0, T_aug, transformation_parameters,\n",
@@ -398,9 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "aug_transform = sitk.Similarity2DTransform() if dimension==2 else sitk.Similarity3DTransform()\n",
@@ -471,9 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%timeit -n1 -r1\n",
@@ -508,9 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%timeit -n1 -r1\n",
@@ -564,9 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def radial_distort(image, k1, k2, k3, distortion_center=None):\n",
@@ -724,9 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "intensity_augmented_images = augment_images_intensity(data, os.path.join(OUTPUT_DIR, 'intensity_aug'), 'mha')\n",
@@ -760,9 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def mult_and_add_intensity_fields(original_image):\n",
@@ -822,7 +817,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/tests/additional_dictionary.txt
+++ b/tests/additional_dictionary.txt
@@ -158,6 +158,7 @@ TransformContinuousIndexToPhysicalPoint
 TransformPoint
 TranslationTransform
 UInt
+VGG
 Vandemeulebroucke
 VectorConfidenceConnected
 VersorRigid
@@ -247,6 +248,7 @@ overfitting
 param
 pixelated
 pre
+pretrained
 py
 pyplot
 recognised
@@ -282,6 +284,7 @@ sitkVectorInt
 sitkVectorUInt
 sitkWelchWindowedSinc
 spatio
+spc
 stepLength
 subsampling
 supersampling


### PR DESCRIPTION
Adding missing documentation for the Otsu based cropping.
Adding more details with respect to the options for the creating the
reference domain. It can either be arbitrary sized (useful when you
are constrained by a pretrained model) but then pixel spacing is
likely non-isotropic. On the other hand you can force isotropic pixel
sizes and select one of the axis sizes which determines all other axis sizes.