### PR TITLE
Adding a copy of the environment.yml in the repo's root directory.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: sitkpy
+
+channels:
+  - simpleitk
+
+dependencies:
+  - python=3.6
+  - jupyter
+  - matplotlib
+  - ipywidgets
+  - numpy
+  - scipy
+  - pandas
+  - SimpleITK>=1.1.0


### PR DESCRIPTION
In theory we could use a symbolic link, but on windows git will replace the
link with a text file named environment.yml which contains the
path to the original file.