### PR TITLE
Increasing the timeout for circleci command.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
           command: |
             source ~/sitkpy/bin/activate
             ~/sitkpy/bin/pytest -v --tb=short tests/test_notebooks.py::Test_notebooks::test_python_notebook
+          no_output_timeout: 30m
 
       - save_cache:
           key: notebook-data-{{ checksum "Data/manifest.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             source ~/sitkpy/bin/activate
             ~/sitkpy/bin/pytest -v --tb=short tests/test_notebooks.py::Test_notebooks::test_python_notebook
-          no_output_timeout: 30m
+          no_output_timeout: 1h
 
       - save_cache:
           key: notebook-data-{{ checksum "Data/manifest.json" }}

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -269,7 +269,7 @@ class Test_notebooks(object):
                     '--execute',
                     '--ExecutePreprocessor.kernel_name='+kernel_name, 
                     '--ExecutePreprocessor.allow_errors=True',
-                    '--ExecutePreprocessor.timeout=600', # seconds till timeout 
+                    '--ExecutePreprocessor.timeout=1800', # seconds till timeout
                     '--output', fout.name, path]
             subprocess.check_call(args)
             nb = nbformat.read(fout.name, nbformat.current_nbformat)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -269,7 +269,7 @@ class Test_notebooks(object):
                     '--execute',
                     '--ExecutePreprocessor.kernel_name='+kernel_name, 
                     '--ExecutePreprocessor.allow_errors=True',
-                    '--ExecutePreprocessor.timeout=1800', # seconds till timeout
+                    '--ExecutePreprocessor.timeout=3600', # seconds till timeout
                     '--output', fout.name, path]
             subprocess.check_call(args)
             nb = nbformat.read(fout.name, nbformat.current_nbformat)


### PR DESCRIPTION
The tests were failing with "Too long with no output (exceeded 10m0s)"
error message. I increased the ellapsed time a command can run without
output from the default 10 minutes to 30 minutes.

Documentation of no_output_timeout is here
https://circleci.com/docs/2.0/configuration-reference/