### PR TITLE
Skip notebook 35_Segmentation_Shape_Analysis.ipynb which times out on…

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -93,7 +93,8 @@ class Test_notebooks(object):
                               '32_Watersheds_Segmentation.ipynb',
                               '33_Segmentation_Thresholding_Edge_Detection.ipynb',
                               '34_Segmentation_Evaluation.ipynb',
-                              '35_Segmentation_Shape_Analysis.ipynb',
+                              pytest.param('35_Segmentation_Shape_Analysis.ipynb', marks=pytest.mark.skipif(os.environ.get('CIRCLECI')=='true', \
+                                                                                                            reason="runtime too long for CircleCI")),
                               #'41_Progress.ipynb', # This notebook times out when run with nbconvert, due to javascript issues, so not tested.
                               '51_VH_Segmentation1.ipynb',
                               '55_VH_Resample.ipynb',


### PR DESCRIPTION
… CircleCI.

This notebook takes too long (increasing the allowed runtime on
CircleCI (no_output_timeout) and in the nbconvert up to 1 hour didn't
help. This test will be skipped on CircleCI.