### PR TITLE
Removing hyperlink to ImageJ.

### DIFF
--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -706,7 +706,7 @@
     "\n",
     "## Image Display\n",
     "\n",
-    "While SimpleITK does not do visualization, it does contain a built in ``Show`` method. This function writes the image out to disk and than launches a program for visualization. By default it is configured to use <a href=\"https://imagej.nih.gov/ij/\">ImageJ</a>, because it readily supports many medical image formats and loads quickly. However, the ``Show`` visualization program is easily customizable by an environment variable:\n",
+    "While SimpleITK does not do visualization, it does contain a built in ``Show`` method. This function writes the image out to disk and than launches a program for visualization. By default it is configured to use ImageJ, because it readily supports many medical image formats and loads quickly. However, the ``Show`` visualization program is easily customizable by an environment variable:\n",
     "\n",
     "<ul>\n",
     "<li>SITK_SHOW_COMMAND: Viewer to use (<a href=\"http://www.itksnap.org\">ITK-SNAP</a>, <a href=\"http://www.slicer.org\">3D Slicer</a>...) </li>\n",


### PR DESCRIPTION
The NIH URL was unstable resulting in failed tests. This is
intermitent, so I am removing the link.