### PR TITLE
Fix issue with SWIG not exporting internal enumeration variables.

### DIFF
--- a/R/Image_Basics.ipynb
+++ b/R/Image_Basics.ipynb
@@ -56,7 +56,7 @@
    },
    "outputs": [],
    "source": [
-    "get(\".__E___itk__simple__PixelIDValueEnum\", pos=\"package:SimpleITK\")"
+    "getAnywhere(\".__E___itk__simple__PixelIDValueEnum\")"
    ]
   },
   {


### PR DESCRIPTION
The get R method only has access to variables that are exported. The
getAnywhere has access to all variables.