### PR TITLE
Adding example of color DICOM image and the use of a color space.

### DIFF
--- a/Data/manifest.json
+++ b/Data/manifest.json
@@ -224,5 +224,8 @@
 "mr_slice_atlas/readme.txt": {
   "archive": "true",
     "sha512":"75af77c4c00deae815da507e2c84b764114080578dc621434d5b587445a93923b8ab98e4ed2ec1547498c24ab0cb0fd872a06e4fbc55818eafb43db645f78ca5"
- }
+},
+"photo.dcm": {
+    "sha512":"d5200d39d5e8bd079a703384a31f0361939753d62c96bcdaabadb1695e6f051adcd1e2e53e795dee8888fd07d63589d138d6c83fc891a390ea5cbedba35ee45b"
+}
 }

--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -62,9 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
@@ -96,9 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "logo = sitk.ReadImage(fdata('SimpleITK.jpg'))\n",
@@ -130,9 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "image_3D = sitk.Image(256, 128, 64, sitk.sitkInt16)\n",
@@ -153,9 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "image_3D.SetOrigin((78.0, 76.0, 77.0))\n",
@@ -177,9 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(image_3D.GetDimension())\n",
@@ -198,9 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(image_2D.GetSize())\n",
@@ -217,9 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(image_3D.GetPixelIDValue())\n",
@@ -237,9 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(image_RGB.GetDimension())\n",
@@ -259,9 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "help(image_3D.GetPixel)"
@@ -270,9 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(image_3D.GetPixel(0, 0, 0))\n",
@@ -297,9 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Brute force sub-sampling \n",
@@ -341,9 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Version 0: get the numpy array and assign the value via broadcast - later on you will need to construct \n",
@@ -402,9 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nda = sitk.GetArrayFromImage(image_3D)\n",
@@ -420,7 +394,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "simpleitk_error_expected": "assignment destination is read-only"
    },
    "outputs": [],
@@ -447,9 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nda = np.zeros((10,20,3))\n",
@@ -475,9 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def my_algorithm(image_as_numpy_array):\n",
@@ -514,7 +483,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "simpleitk_error_expected": "Inputs do not occupy the same physical space!"
    },
    "outputs": [],
@@ -559,9 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "img = sitk.ReadImage(fdata('SimpleITK.jpg'))\n",
@@ -583,7 +549,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "simpleitk_error_allowed": "Image RGB array must be uint8 or floating point; found uint16"
    },
    "outputs": [],
@@ -620,9 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data_directory = os.path.dirname(fdata(\"CIRS057A_MR_CT_DICOM/readme.txt\"))\n",
@@ -658,9 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sitk.WriteImage(sitk.Cast(sitk.RescaleIntensity(written_image), sitk.sitkUInt8), \n",
@@ -677,9 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data_directory = os.path.dirname(fdata(\"CIRS057A_MR_CT_DICOM/readme.txt\"))\n",
@@ -722,9 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "reader.SetFileNames(series_file_names[selected_series])\n",
@@ -733,6 +690,63 @@
     "z = int(img.GetDepth()/2)\n",
     "plt.imshow(sitk.GetArrayViewFromImage(img)[z,:,:], cmap=plt.cm.Greys_r)\n",
     "plt.axis('off');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multi-channel images and color\n",
+    "\n",
+    "Generally speaking, SimpleITK represents color images as multi-channel images independent of a [color space](https://en.wikipedia.org/wiki/Color_space). It is up to you to interpret the channels correctly based on additional color space knowledge prior to using them for display or any other purpose.\n",
+    "\n",
+    "The following cells illustrate reading and interpretation of an interesting image in DICOM format. It is a photograph of an X-ray on a light box (yes, there are some strange things in the wild). The meta-data dictionary for this image contains the relevant information that will allow us to intelligently interpret it.\n",
+    "\n",
+    "We will look at the image's modality (0008|0060), which in our case is XC, which stands for \"External Camera Photography\". After reading the image we see that it has three channels and try to display it. At this point we realize that something is wrong, and we check the image's Photometric Interpretation (0028|0004), color space in DICOM speak. We then modify the pixel values so that we can display them using our image viewer's expected color space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
+   },
+   "outputs": [],
+   "source": [
+    "xray_photo = sitk.ReadImage(fdata('photo.dcm'))\n",
+    "print('Image Modality: {0}'.format(xray_photo.GetMetaData('0008|0060')))\n",
+    "print('Number of channels: {0}'.format(xray_photo.GetNumberOfComponentsPerPixel()))\n",
+    "\n",
+    "# Display the image using Fiji which expects the channels to be in the RGB color space\n",
+    "sitk.Show(xray_photo)\n",
+    "\n",
+    "# In what color space are the pixels?\n",
+    "print('Photomertic Interpretation: {0}'.format(xray_photo.GetMetaData('0028|0004')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
+   },
+   "outputs": [],
+   "source": [
+    "# Our pixels are in the YCbCr color space, and we want them in RGB, so we need to change the representation\n",
+    "def full_ycbcr_to_rgb(image):\n",
+    "    channels = [sitk.VectorIndexSelectionCast(image,i, sitk.sitkFloat32) for i in range(image.GetNumberOfComponentsPerPixel())]\n",
+    "    chan0 = channels[0]\n",
+    "    chan1 = channels[1] - 128\n",
+    "    chan2 = channels[2] - 128\n",
+    "    return sitk.Compose([sitk.Clamp(chan0 + 1.402*chan2, sitk.sitkUInt8),\n",
+    "                         sitk.Clamp(chan0 - 0.114 * 1.772 / 0.587*chan1 - 0.299 * 1.402 / 0.587*chan2, sitk.sitkUInt8),\n",
+    "                         sitk.Clamp(chan0 + 1.772*chan1, sitk.sitkUInt8)])\n",
+    "\n",
+    "sitk.Show(full_ycbcr_to_rgb(xray_photo))\n",
+    "\n",
+    "# x-rays are expected to be a single channel gray scale image and not a color image. To obtain a gray scale image\n",
+    "# corresponding to the original three channel image we only need to take the luminance (Y channel).\n",
+    "sitk.Show(sitk.VectorIndexSelectionCast(xray_photo,0))"
    ]
   },
   {
@@ -886,9 +900,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "result_img = streaming_subtract(image1_file_name, image2_file_name, parts=5)\n",
@@ -898,9 +910,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "result_img = sitk.ReadImage(image1_file_name) - sitk.ReadImage(image2_file_name)\n",
@@ -925,7 +935,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/tests/additional_dictionary.txt
+++ b/tests/additional_dictionary.txt
@@ -222,8 +222,10 @@ VersorRigid
 VersorTransform
 VolView
 WriteImage
+XC
 XVth
 XX
+YCbCr
 YY
 Yaniv
 ZYX


### PR DESCRIPTION
Illustrating the fact that SimpleITK is agnostic to the color space
and that the user needs to convert the data to the relevant color
space for display purposes.