### PR TITLE
Remove testing for python3.5 and add testing for python3.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,13 +50,13 @@ jobs:
           key: notebook-data-{{ checksum "Data/manifest.json" }}
           paths: 
             - /home/circleci/.ExternalData
-  test-3.5:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.5
   test-3.6:
     <<: *test-template
     docker:
       - image: circleci/python:3.6
+  test-3.7:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.7
 
   


### PR DESCRIPTION
We will now test the notebooks for python versions 2.7, 3.6, 3.7.
Test 2.7 for backwards compatability and the last two 3.x versions.