### PR TITLE
Adding a reference to a paper dealing with aliasing in CNN.

### DIFF
--- a/Python/70_Data_Augmentation.ipynb
+++ b/Python/70_Data_Augmentation.ipynb
@@ -43,7 +43,10 @@
     "\n",
     "In many cases, data prepared for use with a deep learning network is resampled to a fixed size. When we perform data augmentation via spatial transformations we also perform resampling. \n",
     "\n",
-    "Admittedly, the example below is exaggerated to illustrate the point, but it serves as a reminder that you may want to consider smoothing your images prior to resampling. "
+    "Admittedly, the example below is exaggerated to illustrate the point, but it serves as a reminder that you may want to consider smoothing your images prior to resampling. \n",
+    "\n",
+    "The effects of aliasing also play a role in network performance stability:\n",
+    "A. Azulay, Y. Weiss, \"Why do deep convolutional networks generalize so poorly to small image transformations?\"  [CoRR abs/1805.12177](https://arxiv.org/abs/1805.12177), 2018."
    ]
   },
   {

--- a/tests/additional_dictionary.txt
+++ b/tests/additional_dictionary.txt
@@ -3,6 +3,7 @@ API
 Acknowledgements
 AffineTransform
 Args
+Azulay
 BFGS
 BMP
 BSpline
@@ -28,6 +29,7 @@ Centre
 CheckerBoardImageFilter
 Clarysse
 Clin
+CoRR
 ComposeImageFilter
 ConfidenceConnected
 ConjugateGradientLineSearch
@@ -264,6 +266,7 @@ condylar
 const
 convergenceMinimumValue
 convergenceWindowSize
+convolutional
 cryosectioning
 cthead
 ctrl


### PR DESCRIPTION
Added reference illustrates the aliasing problems that arise when subsampling
(most often max pooling) in CNNs.