### PR TITLE
Addressing issues with DICOM photometric interpretation.

### DIFF
--- a/Data/manifest.json
+++ b/Data/manifest.json
@@ -234,5 +234,8 @@
 },
 "microscopy_colocalization.nrrd" : {
  "sha512": "f25d3b08cbc697752ad61ceb51c047d1cadbd2cdf12e635d8ddcb2f8cb27ea4dffb0dc4e1b932aa8d6aeb4318fe00f59f0f88bbc8e6bae727ce800c78c11d4e7"
+},
+"cxr.dcm" : {
+ "sha512": "06395fc6ca54f2f2816b85e68b0a7ac6d0f1fb1158f3bca28c5a5f1fd8a9e99ebf83f01745f87f191fcbd2ffa8f65e8fdaf2a2b8268a8aa733c554263361be05"
 }
 }

--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -696,13 +696,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Multi-channel images and color\n",
+    "### DICOM photometric interpretation \n",
     "\n",
     "Generally speaking, SimpleITK represents color images as multi-channel images independent of a [color space](https://en.wikipedia.org/wiki/Color_space). It is up to you to interpret the channels correctly based on additional color space knowledge prior to using them for display or any other purpose.\n",
     "\n",
-    "The following cells illustrate reading and interpretation of an interesting image in DICOM format. It is a photograph of an X-ray on a light box (yes, there are some strange things in the wild). The meta-data dictionary for this image contains the relevant information that will allow us to intelligently interpret it.\n",
+    "The following cells illustrate reading and interpretation of interesting images in DICOM format. The first is a photograph of an X-ray on a light box (yes, there are some strange things in the wild). The second is a digital X-ray. While both of these are chest X-rays they differ in image modality (0008|0060) and in Photometric Interpretation (0028|0004), color space in DICOM speak.\n",
     "\n",
-    "We will look at the image's modality (0008|0060), which in our case is XC, which stands for \"External Camera Photography\". After reading the image we see that it has three channels and try to display it. At this point we realize that something is wrong, and we check the image's Photometric Interpretation (0028|0004), color space in DICOM speak. We then modify the pixel values so that we can display them using our image viewer's expected color space."
+    "Things to note:\n",
+    "1. When using SimpleITK to read a color DICOM image, the channel values will be transformed to the RGB color space.\n",
+    "2. When using SimpleITK to read a scalar image, the photometric interpretation is ignored and always assumed to be MONOCHROME2 (lowest value displayed as black). This means that it is up to you, the user to check this value and if it is MONOCHROME1 (lowest value displayed as white), invert the pixel values."
    ]
   },
   {
@@ -713,15 +715,21 @@
    },
    "outputs": [],
    "source": [
-    "xray_photo = sitk.ReadImage(fdata('photo.dcm'))\n",
-    "print('Image Modality: {0}'.format(xray_photo.GetMetaData('0008|0060')))\n",
-    "print('Number of channels: {0}'.format(xray_photo.GetNumberOfComponentsPerPixel()))\n",
-    "\n",
-    "# Display the image using Fiji which expects the channels to be in the RGB color space\n",
-    "sitk.Show(xray_photo)\n",
-    "\n",
-    "# In what color space are the pixels?\n",
-    "print('Photomertic Interpretation: {0}'.format(xray_photo.GetMetaData('0028|0004')))"
+    "xrays = [sitk.ReadImage(fdata('photo.dcm')),\n",
+    "         sitk.ReadImage(fdata('cxr.dcm'))]\n",
+    "for img in xrays:\n",
+    "    print('Image Modality: {0}'.format(img.GetMetaData('0008|0060')))\n",
+    "    print('Number of channels: {0}'.format(img.GetNumberOfComponentsPerPixel()))\n",
+    "    print('Photomertic Interpretation: {0}'.format(img.GetMetaData('0028|0004')))\n",
+    "    # Display the image using Fiji which expects the channels to be in the RGB color space\n",
+    "    sitk.Show(img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Both x-ray images require modification. The first, is a color sRGB image while an x-ray should be a single channel gray scale image. We will [convert sRGB to gray scale](https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale). For the second, the photometric interpretation indicates that the lowest value should be mapped to white and not to black. We will invert the intensities."
    ]
   },
   {
@@ -732,21 +740,20 @@
    },
    "outputs": [],
    "source": [
-    "# Our pixels are in the YCbCr color space, and we want them in RGB, so we need to change the representation\n",
-    "def full_ycbcr_to_rgb(image):\n",
+    "def srgb2gray(image):\n",
+    "    # Convert sRGB image to gray scale and rescale results to [0,255]    \n",
     "    channels = [sitk.VectorIndexSelectionCast(image,i, sitk.sitkFloat32) for i in range(image.GetNumberOfComponentsPerPixel())]\n",
-    "    chan0 = channels[0]\n",
-    "    chan1 = channels[1] - 128\n",
-    "    chan2 = channels[2] - 128\n",
-    "    return sitk.Compose([sitk.Clamp(chan0 + 1.402*chan2, sitk.sitkUInt8),\n",
-    "                         sitk.Clamp(chan0 - 0.114 * 1.772 / 0.587*chan1 - 0.299 * 1.402 / 0.587*chan2, sitk.sitkUInt8),\n",
-    "                         sitk.Clamp(chan0 + 1.772*chan1, sitk.sitkUInt8)])\n",
+    "    #linear mapping\n",
+    "    I = 1/255.0*(0.2126*channels[0] + 0.7152*channels[1] + 0.0722*channels[2])\n",
+    "    #nonlinear gamma correction\n",
+    "    I = I*sitk.Cast(I<=0.0031308,sitk.sitkFloat32)*12.92 + I**(1/2.4)*sitk.Cast(I>0.0031308,sitk.sitkFloat32)*1.055-0.55\n",
+    "    return sitk.Cast(sitk.RescaleIntensity(I), sitk.sitkUInt8)\n",
     "\n",
-    "sitk.Show(full_ycbcr_to_rgb(xray_photo))\n",
+    "sitk.Show(srgb2gray(xrays[0]))\n",
     "\n",
-    "# x-rays are expected to be a single channel gray scale image and not a color image. To obtain a gray scale image\n",
-    "# corresponding to the original three channel image we only need to take the luminance (Y channel).\n",
-    "sitk.Show(sitk.VectorIndexSelectionCast(xray_photo,0))"
+    "mmFilter = sitk.MinimumMaximumImageFilter()\n",
+    "mmFilter.Execute(xrays[1])\n",
+    "sitk.Show(sitk.InvertIntensity(xrays[1], maximum=mmFilter.GetMaximum()))"
    ]
   },
   {
@@ -935,7 +942,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tests/additional_dictionary.txt
+++ b/tests/additional_dictionary.txt
@@ -414,6 +414,7 @@ parallelization
 param
 parametrization
 parametrized
+photometric
 pixelated
 plafond
 pn
@@ -438,6 +439,7 @@ rescale
 rgb
 roi
 runtime
+sRGB
 sagittal
 scaleFactors
 scipy


### PR DESCRIPTION
ITK changed the way it read images with photometric interpretation
that indicates color images (e.g. YBR_FULL_422). Instead of loading
the raw channels as vector pixels, they are now converted to RGB.

This commit also addresses the ITK decision to ignore photometric
interpretation of MONOCHROME1 (minimum value displayed as white). ITK
loads the image as is, and the user needs to invert it for display.