### PR TITLE
Allow error in slice to volume registration.

### DIFF
--- a/Python/63_Registration_Initialization.ipynb
+++ b/Python/63_Registration_Initialization.ipynb
@@ -619,7 +619,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+   "simpleitk_error_allowed": "All samples map outside moving image buffer."
+   },
    "outputs": [],
    "source": [
     "expanded_fixed_image_slice = sitk.Expand(fixed_image_slice, [1,1,4], sitk.sitkLinear)\n",


### PR DESCRIPTION
In the testing framework the slice to volume registration may fail
(too many samples outside moving image) because we use a much smaller
image due to memory constraints. Accomodate for these occasional
failures by allowing them.