### PR TITLE
Added Readme Link to `insightsoftwareconsortium.github.io/SimpleITK-Notebooks/ `

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Ubuntu](https://github.com/InsightSoftwareConsortium/SimpleITK-Notebooks/workflows/Ubuntu%20Pytest/badge.svg)
 &nbsp;&nbsp;![Windows](https://github.com/InsightSoftwareConsortium/SimpleITK-Notebooks/workflows/Windows%20Pytest/badge.svg)
-[![http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/)
+&nbsp;&nbsp;[![http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/)
 
 http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/
 


### PR DESCRIPTION
I think the Links to the notebooks page should be accessible from the README.
I've also added a badge following this pattern:
https://naereen.github.io/badges/