### PR TITLE
Removed meta information from cells + deleted all empty cells.

### DIFF
--- a/Python/04_Image_Display.ipynb
+++ b/Python/04_Image_Display.ipynb
@@ -31,9 +31,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Image Display with An External Viewer\n",
     "\n",
@@ -290,9 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Inline display with matplotlib and ipywidgets\n",
     "\n",

--- a/Python/05_Results_Visualization.ipynb
+++ b/Python/05_Results_Visualization.ipynb
@@ -363,9 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "color_maps = {\n",

--- a/Python/10_matplotlib's_imshow.ipynb
+++ b/Python/10_matplotlib's_imshow.ipynb
@@ -14,9 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -82,9 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def myshow(img):\n",
@@ -127,9 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def myshow(img, title=None, margin=0.05, dpi=80):\n",
@@ -331,9 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def myshow3d(img, xslices=[], yslices=[], zslices=[], title=None, margin=0.05, dpi=80):\n",

--- a/Python/11_Progress.ipynb
+++ b/Python/11_Progress.ipynb
@@ -552,13 +552,6 @@
    "source": [
     "?threading.Thread.start"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -579,18 +572,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.5"
-  },
-  "widgets": {
-   "state": {
-    "9a054c9be681481883144bf87c555169": {
-     "views": [
-      {
-       "cell_index": 3
-      }
-     ]
-    }
-   },
-   "version": "1.2.0"
   }
  },
  "nbformat": 4,

--- a/Python/300_Segmentation_Overview.ipynb
+++ b/Python/300_Segmentation_Overview.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "# Introduction to ITK Segmentation in SimpleITK Notebooks <a href=\"https://mybinder.org/v2/gh/InsightSoftwareConsortium/SimpleITK-Notebooks/master?filepath=Python%2F300_Segmentation_Overview.ipynb\"><img style=\"float: right;\" src=\"https://mybinder.org/badge_logo.svg\"></a>\n",
     "\n",
@@ -350,13 +348,6 @@
    "source": [
     "myshow(sitk.LabelOverlay(img_T1_255, ls > 0))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/30_Segmentation_Region_Growing.ipynb
+++ b/Python/30_Segmentation_Region_Growing.ipynb
@@ -80,9 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "initial_seed_point_indexes = point_acquisition_interface.get_point_indexes()"
@@ -236,15 +234,6 @@
     "    title_list=[\"before morphological closing\", \"after morphological closing\"],\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/32_Watersheds_Segmentation.ipynb
+++ b/Python/32_Watersheds_Segmentation.ipynb
@@ -288,13 +288,6 @@
     "mo_img = sitk.Mask(md_img, e_img)\n",
     "myshow(sitk.LabelOverlay(img, mo_img), \"Multi-label Closing\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/34_Segmentation_Evaluation.ipynb
+++ b/Python/34_Segmentation_Evaluation.ipynb
@@ -556,13 +556,6 @@
     "    + str(surface_hausdorff_distance(reference_segmentation2, seg))\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/35_Segmentation_Shape_Analysis.ipynb
+++ b/Python/35_Segmentation_Shape_Analysis.ipynb
@@ -398,9 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, axes = plt.subplots(nrows=len(cols), ncols=2, figsize=(6, 4 * len(cols)))\n",
@@ -438,9 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bacteria_labels = shape_stats.GetLabels()\n",
@@ -486,13 +482,6 @@
     "    obb_img = sitk.PermuteAxes(obb_img, [2, 1, 0])\n",
     "    gui.MultiImageDisplay(image_list=[obb_img], title_list=[f\"OBB_{label}\"])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/36_Microscopy_Colocalization_Distance_Analysis.ipynb
+++ b/Python/36_Microscopy_Colocalization_Distance_Analysis.ipynb
@@ -51,9 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sim_image = sitk.ReadImage(fdata(\"microscopy_colocalization.nrrd\"))\n",
@@ -144,9 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from numba import njit\n",
@@ -271,9 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Compute the edge to edge distances using the absolute distance map from the nuclei segmentation.\n",

--- a/Python/55_VH_Resample.ipynb
+++ b/Python/55_VH_Resample.ipynb
@@ -170,13 +170,6 @@
     "    temp, [os.path.join(OUTPUT_DIR, f\"r{i:03d}.jpg\") for i in range(temp.GetSize()[2])]\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/56_VH_Registration1.ipynb
+++ b/Python/56_VH_Registration1.ipynb
@@ -196,9 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "outTx = R.Execute(\n",

--- a/Python/60_Registration_Introduction.ipynb
+++ b/Python/60_Registration_Introduction.ipynb
@@ -378,9 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Post registration analysis"
    ]
@@ -459,13 +457,6 @@
     "    final_transform, os.path.join(OUTPUT_DIR, \"RIRE_training_001_CT_2_mr_T1.tfm\")\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/61_Registration_Introduction_Continued.ipynb
+++ b/Python/61_Registration_Introduction_Continued.ipynb
@@ -557,13 +557,6 @@
    "source": [
     "print(final_transform)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/62_Registration_Tuning.ipynb
+++ b/Python/62_Registration_Tuning.ipynb
@@ -263,9 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#%%timeit -r1 -n1\n",
@@ -373,13 +371,6 @@
     "    f\"After registration, errors in millimeters, mean(std): {final_errors_mean:.2f}({final_errors_std:.2f}), max: {final_errors_max:.2f}\"\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/63_Registration_Initialization.ipynb
+++ b/Python/63_Registration_Initialization.ipynb
@@ -147,9 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "initial_transform = sitk.CenteredTransformInitializer(\n",
@@ -612,9 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "final_transform, _ = multires_registration(fixed_image, moving_image, initial_transform)\n",

--- a/Python/64_Registration_Memory_Time_Tradeoff.ipynb
+++ b/Python/64_Registration_Memory_Time_Tradeoff.ipynb
@@ -324,13 +324,6 @@
     "* Change the interpolation method for the \"original resolution\" registration to nearest neighbor.\n",
     "* Change the resolution of the resampled image - will a higher resolution always result in faster running times?"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/65_Registration_FFD.ipynb
+++ b/Python/65_Registration_FFD.ipynb
@@ -332,9 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Multi-resolution control point grid\n",
     "\n",

--- a/Python/66_Registration_Demons.ipynb
+++ b/Python/66_Registration_Demons.ipynb
@@ -572,13 +572,6 @@
     "    x_coords, y_coords = zip(*transformed_contour)\n",
     "    axes[1].plot(x_coords, y_coords, linewidth=5)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -599,18 +592,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.5"
-  },
-  "widgets": {
-   "state": {
-    "feffa7c0572f431fb5e77268dd7a390f": {
-     "views": [
-      {
-       "cell_index": 5
-      }
-     ]
-    }
-   },
-   "version": "1.2.0"
   }
  },
  "nbformat": 4,

--- a/Python/67_Registration_Semiautomatic_Homework.ipynb
+++ b/Python/67_Registration_Semiautomatic_Homework.ipynb
@@ -295,9 +295,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## <font color=\"red\">Answer</font> the following questions:\n",
     "\n",
@@ -308,15 +306,6 @@
     "2. Avoid the temptation to <a href=\"https://en.wikipedia.org/wiki/Overfitting\">overfit</a>: When we only have pairs of manually localized points we may be tempted to use all of the point pairs and estimate a transformation that has more degrees of freedom. In our case, an affine transformation instead of a rigid one. To illustrate the problem with this approach you will manually localize four points in the two images. Estimate a rigid and an affine transformation using these points (change the transform type given as input to LandmarkBasedTransformInitializer).<br><br> \n",
     "Now compute the FRE associated with the two transformations and the TRE (using the fixed_points and moving_points data). Did the use of more degrees of freedom improve the registration results (smaller TREs)?"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -337,32 +326,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.5"
-  },
-  "widgets": {
-   "state": {
-    "533c967c71954d0ba484f642667e3b98": {
-     "views": [
-      {
-       "cell_index": 10
-      }
-     ]
-    },
-    "65a69dcc8b734278bf7f85bbbb7b10ea": {
-     "views": [
-      {
-       "cell_index": 5
-      }
-     ]
-    },
-    "cffd349d2e4e4ab28219c46e5769e04b": {
-     "views": [
-      {
-       "cell_index": 15
-      }
-     ]
-    }
-   },
-   "version": "1.2.0"
   }
  },
  "nbformat": 4,

--- a/Python/68_Registration_Errors.ipynb
+++ b/Python/68_Registration_Errors.ipynb
@@ -37,9 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import SimpleITK as sitk\n",
@@ -86,10 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "manipulation_interface = PairedPointDataManipulation(sitk.Euler2DTransform())"
@@ -97,9 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Sensitivity to outliers\n",
     "\n",
@@ -111,9 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ideal_fixed_fiducials = [\n",
@@ -141,9 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Registration with perfect data (no noise or outliers)\n",
@@ -226,9 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Registration with same bias added to all points\n",
@@ -323,9 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fiducials = [\n",

--- a/Python/69_x-ray-panorama.ipynb
+++ b/Python/69_x-ray-panorama.ipynb
@@ -114,9 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The ROI we specify is in a region that is expected to have uniform intensities.\n",
@@ -475,9 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "metric_sampling_percentage = 0.2\n",
@@ -701,13 +697,6 @@
     "\n",
     "    print(f\"Angle is (degrees): {np.degrees(angle)}\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Python/70_Data_Augmentation.ipynb
+++ b/Python/70_Data_Augmentation.ipynb
@@ -116,9 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def disp_images(images, fig_size, wl_list=None):\n",
@@ -550,9 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "aug_transform = (\n",
@@ -638,9 +634,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## What about flipping\n",
     "\n",
@@ -975,9 +969,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def sigmoid_mapping(\n",
@@ -1027,9 +1019,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",

--- a/Python/71_Trust_But_Verify.ipynb
+++ b/Python/71_Trust_But_Verify.ipynb
@@ -680,9 +680,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with open(faux_image_volume_file_name, \"rb\") as fp:\n",
@@ -737,9 +735,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with open(faux_series_volume_file_name, \"rb\") as fp:\n",


### PR DESCRIPTION
As the diff in Jupyter notebooks look a bit ugly (see #319), 
I run the comment `nbstripout Python/*.ipynb --strip-empty-cells` to keep the metadata from the notebooks as clean as possible. With this, the diff in a pull request will look less cluttered when opening the notebooks on different devices.
Most of all, it changed the "collapsed" parameter, which defines if the cell output is collapsed or not. For code, this parameter is not needed, as all cells are not yet executed. And for Markdown, I don't know what it does, but it had no effect on the look of my local notebook. https://nbformat.readthedocs.io/en/latest/format_description.html#code-cells