### PR TITLE
Improve approach to dealing with broken links.

### DIFF
--- a/Python/34_Segmentation_Evaluation.ipynb
+++ b/Python/34_Segmentation_Evaluation.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "The relevant criteria are task dependent, so you need to ask yourself whether you are interested in detecting spurious errors or not (mean or max surface distance), whether over/under segmentation should be differentiated (volume similarity and Dice or just Dice), and what is the ratio between acceptable errors and the size of the segmented object (Dice coefficient may be too sensitive to small errors when the segmented object is small and not sensitive enough to large errors when the segmented object is large).\n",
     "\n",
-    "The data we use in the notebook is a set of manually segmented liver tumors from a single clinical CT scan. A larger dataset (four scans) is freely available from this [MIDAS repository](http://www.insight-journal.org/midas/collection/view/38). The relevant publication is: T. Popa et al., \"Tumor Volume Measurement and Volume Measurement Comparison Plug-ins for VolView Using ITK\", SPIE Medical Imaging: Visualization, Image-Guided Procedures, and Display, 2006.\n",
+    "The data we use in the notebook is a set of manually segmented liver tumors from a single clinical CT scan. The relevant publication is: T. Popa et al., \"Tumor Volume Measurement and Volume Measurement Comparison Plug-ins for VolView Using ITK\", SPIE Medical Imaging: Visualization, Image-Guided Procedures, and Display, 2006.\n",
     "\n",
     "<b>Note</b>: The approach described here can also be used to evaluate Registration, as illustrated in the [free form deformation notebook](65_Registration_FFD.ipynb)."
    ]

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -13,12 +13,7 @@ from enchant.tokenize import Filter, EmailFilter, URLFilter
 from enchant import DictWithPWL
 
 from lxml.html import document_fromstring, etree
-try:
-   # Python 3
-   from urllib.request import urlopen, URLError
-except ImportError:
-   from urllib2 import urlopen, URLError
-
+from urllib.request import urlopen, URLError, Request
 
 
 """
@@ -206,7 +201,9 @@ class Test_notebooks(object):
                        url = 'file:' + urllib.request.pathname2url(document_link[2])
                     else:  # Remote file.
                        url = document_link[2]
-                    urlopen(url)
+                    # mimic a web browser request, otherwise some sites return
+                    # "HTTP Error 403: Forbidden" to prevent web scraping
+                    urlopen(Request(url, headers={'User-Agent':'Mozilla/5.0'}))
                  except URLError:
                     broken_links.append(url)
               if broken_links:


### PR DESCRIPTION
Some sites check that the request is coming from a browser to
preclude web scraping, so the test now mimics a browser request. The
previously referenced link in the notebook has been removed, site no
longer available.