### PR TITLE
Address memory issues with CI.

### DIFF
--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -61,6 +61,10 @@
    "source": [
     "import SimpleITK as sitk\n",
     "\n",
+    "# If the environment variable SIMPLE_ITK_MEMORY_CONSTRAINED_ENVIRONMENT is set, this will override the ReadImage\n",
+    "# function so that it also resamples the image to a smaller size (testing environment is memory constrained).\n",
+    "%run setup_for_testing\n",
+    "\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -392,7 +396,7 @@
     "    destinationIndex=[0, 0],\n",
     ")\n",
     "# Set sub image using slicing.\n",
-    "logo[20 : 20 + sz_x, 20 : 20 + sz_y] = color_image\n",
+    "logo[20 : 20 + sz_x, 0:sz_y] = color_image\n",
     "\n",
     "sitk.Show(logo)"
    ]
@@ -668,7 +672,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "simpleitk_error_expected": "Inputs do not occupy the same physical space"
+   },
    "outputs": [],
    "source": [
     "data_directory = os.path.dirname(fdata(\"CIRS057A_MR_CT_DICOM/readme.txt\"))\n",

--- a/Python/setup_for_testing.py
+++ b/Python/setup_for_testing.py
@@ -13,9 +13,14 @@ import SimpleITK as sitk
 def shrink_decorator(size):
     def inner_decorator(func):
         def func_and_resize(*args, **kwargs):
+            original_image = func(*args, **kwargs)
             shrink_filter = sitk.ShrinkImageFilter()
             shrink_filter.SetShrinkFactor(size)
-            return shrink_filter.Execute(func(*args, **kwargs))
+            f_and_s_image = shrink_filter.Execute(original_image)
+            # Copy metadata dictionary
+            for key in original_image.GetMetaDataKeys():
+                f_and_s_image.SetMetaData(key, original_image.GetMetaData(key))
+            return f_and_s_image
 
         return func_and_resize
 


### PR DESCRIPTION
The 03_Image_Details notebook takes too much memory in CI causing the
kernel to intermittently die during execution. This is addressed by
running the setup_for_testing script in the first cell.

This also exposed an issue with the setup_for_testing script, it
previously did not copy the metadata dictionary of the image returned
by the original function.