### PR TITLE
Skip testing of 03_Image_Details when run via GITHUB_ACTIONS.

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -79,7 +79,8 @@ class Test_notebooks(object):
                              ['00_Setup.ipynb',
                               '01_Image_Basics.ipynb',
                               '02_Pythonic_Image.ipynb',
-                              '03_Image_Details.ipynb',
+                              pytest.param('03_Image_Details.ipynb', marks=pytest.mark.skipif(os.environ.get('GITHUB_ACTIONS')=='true', \
+                                                                                                            reason="on GitHub runners, nbconvert intermittently fails with dead kernel, even after reducing notebook memory usage")),
                               '04_Image_Display.ipynb',
                               '05_Results_Visualization.ipynb',
                               '10_matplotlibs_imshow.ipynb',


### PR DESCRIPTION
Executing notebook using nbconvert fails intermittently with dead
kernel when executed on a GitHub actions runner. The likely problem
was out of memory issue. Changing the notebook to use less memory did
not solve the problem. Also, when trying to debug (connecting via ssh
using the tmate action, mxschmitt/action-tmate) connected to the
runner and had the following experience: (1) Ran nbconvert on the
notebook and the kernel died. (2) Checked the memory setup, free -h,
looked like there is enough memory 3.2GiB (3) Ran nbconvert again and
this time it succeeded.