### PR TITLE
Adding workaround for reading image file from memory.

### DIFF
--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -600,7 +600,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the following cell, we read an image in JPEG format, and write it as PNG and BMP. File formats are deduced from the file extension. Appropriate pixel type is also set - you can override this and force a pixel type of your choice."
+    "In the following cell, we read an image in JPEG format, and write it as PNG and BMP. File formats are deduced from the file extension. Appropriate pixel type is also set - you can override this and force a pixel type of your choice.\n",
+    "\n",
+    "**Note**: When reading an image series, via the `ImageSeriesReader` or via the procedural `ReadImage` interface, the images in the list are assumed to be ordered correctly (`GetGDCMSeriesFileNames` ensures this for DICOM). If the order is incorrect, the image will be read, but its spacing and possibly the direction cosine matrix will be incorrect."
    ]
   },
   {
@@ -1051,6 +1053,119 @@
    "source": [
     "result_img = sitk.ReadImage(image1_file_name) - sitk.ReadImage(image2_file_name)\n",
     "del result_img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Reading from memory\n",
+    "\n",
+    "ITK and consequentially SimpleITK support file based IO. Therefore, to read file data that is in memory we need a workaround. In Python this is relatively straightforward using the tempfile module and function decorators as shown below.\n",
+    "\n",
+    "Note that the same decorator can be used to read a Transformation from memory (decorate the `ReadTransform` function)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {"simpleitk_error_allowed": "Exception thrown in SimpleITK Show:"
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import tempfile\n",
+    "\n",
+    "# If speed is of the essence, override the default temp directory\n",
+    "# and point it to a RAM disk directory, speeding up IO.\n",
+    "# See details: https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir\n",
+    "#\n",
+    "# import os\n",
+    "# os.environ[\"TMPDIR\"] = \"path/to/ram/disk/dir\"\n",
+    "\n",
+    "\n",
+    "def bytes_decorator(file_extension):\n",
+    "    \"\"\"\n",
+    "    A decorator which takes a SimpleITK function which expects a file name and replaces it with one that expects\n",
+    "    a binary blob. The decorator writes a temporary file with the given suffix and the wrapped function is invoked\n",
+    "    with the file. Using the suffix is critical, because the SimpleITK introspection mechanism checks which\n",
+    "    IO component can read a file. Some IO components (e.g MetaImageIO) rely on the file extension.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def decorator(func):\n",
+    "        def wrapper(*args, **kwargs):\n",
+    "            with tempfile.NamedTemporaryFile(mode=\"wb\", suffix=file_extension) as fp:\n",
+    "                fp.write(args[0])\n",
+    "                fp.flush()\n",
+    "                args_list = list(args)\n",
+    "                args_list[0] = fp.name\n",
+    "                return func(*args_list, **kwargs)\n",
+    "\n",
+    "        return wrapper\n",
+    "\n",
+    "    return decorator\n",
+    "\n",
+    "\n",
+    "sitk.ReadMemoryJPG = bytes_decorator(\".jpg\")(sitk.ReadImage)\n",
+    "\n",
+    "# Get binary data from the SimpleITK website\n",
+    "response = requests.get(\n",
+    "    \"https://simpleitk.org/images/SimpleITK-Icons/s-name-full-white.jpg\"\n",
+    ")\n",
+    "if response.ok:\n",
+    "    sitk.Show(sitk.ReadMemoryJPG(response.content))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The decorator above uses default settings for the underlying `ImageFileReader` and creates a reader every time the function is invoked. In some cases this is not sufficiently flexible. The code below illustrates an alternative solution which provides the additional flexibility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_file_from_memory(file_reader, memory_file_blob):\n",
+    "    \"\"\"\n",
+    "    Read the binary data as a file. Binary data is written to disk using the tempfile\n",
+    "    mechanism and the resulting file is read using the pre-configured FileReader. It is\n",
+    "    critical to set the FileReader's specific IO (SetImageIO) to match the type of the file.\n",
+    "    Because the file is written without an extension, SimpleITK cannot use its introspection\n",
+    "    mechanism to automatically identify which IO can read the file because some IOs (e.g. MetaImageIO)\n",
+    "    require a specific file extension, otherwise they claim that they cannot read the file.\n",
+    "    Useful for reading images.\n",
+    "    \"\"\"\n",
+    "    with tempfile.NamedTemporaryFile(mode=\"wb\") as fp:\n",
+    "        fp.write(memory_file_blob)\n",
+    "        fp.flush()\n",
+    "        file_reader.SetFileName(fp.name)\n",
+    "        return file_reader.Execute()\n",
+    "\n",
+    "\n",
+    "image_file_reader = sitk.ImageFileReader()\n",
+    "image_file_reader.SetImageIO(\"GDCMImageIO\")\n",
+    "image_file_reader.LoadPrivateTagsOn()\n",
+    "\n",
+    "sitk.ReadMemoryDCM = bytes_decorator(\".dcm\")(sitk.ReadImage)\n",
+    "\n",
+    "# read file into memory\n",
+    "with open(fdata(\"cxr.dcm\"), \"rb\") as fp:\n",
+    "    binary_data = fp.read()\n",
+    "\n",
+    "# read from memory using the two options\n",
+    "image_opt1 = sitk.ReadMemoryDCM(binary_data)\n",
+    "image_opt2 = read_file_from_memory(image_file_reader, binary_data)\n",
+    "\n",
+    "# The group number (first part of the group|element) of a private\n",
+    "# tag is an odd number. Print the dictionaries for the two options and\n",
+    "# see that the second option includes private tags while the first\n",
+    "# does not.\n",
+    "print(image_opt1.GetMetaDataKeys())\n",
+    "print(image_opt2.GetMetaDataKeys())"
    ]
   }
  ],

--- a/tests/additional_dictionary.txt
+++ b/tests/additional_dictionary.txt
@@ -97,6 +97,7 @@ GeodesicActiveContour
 GetArrayFromImage
 GetArrayViewFromImage
 GetCenter
+GetGDCMSeriesFileNames
 GetHeight
 GetInverse
 GetMetaData
@@ -273,6 +274,7 @@ StimulateImageIO
 Subsampling
 SymmetricForcesDemonsRegistrationFilter
 TIFFImageIO
+TMPDIR
 TRE
 TREs
 ThresholdSegmentation
@@ -357,6 +359,7 @@ defaultPixelValue
 deformable
 dev
 dimensionality
+dir
 disp
 displaystyle
 dissociations
@@ -369,6 +372,7 @@ eikonal
 endospore
 endospores
 env
+environ
 estimateLearningRate
 et
 euler
@@ -455,6 +459,7 @@ optimizerScales
 optimizers
 originalControlPointDisplacements
 originalDisplacements
+os
 otsu
 outlier
 outputDirection
@@ -541,6 +546,7 @@ supersampling
 sys
 sz
 tempdir
+tempfile
 textrm
 tfm
 tgz


### PR DESCRIPTION
As the question about reading image files from memory comes up once in
a while, adding the workaround so that it is clear to users what they
can and can't do with SimpleITK.