### PR TITLE
BUG: Calling GetArrayViewFromImage with temporary SimpleITK image.

### DIFF
--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -422,7 +422,7 @@
     "# Uncomment the following line to see what happens if the slices do not have the same origin.\n",
     "# result1['origin'] = [o+1.0 for o in result1['origin']]\n",
     "try:\n",
-    "    if np.all(sitk.GetArrayViewFromImage(result1 - result2) == 0):\n",
+    "    if np.all(sitk.GetArrayFromImage(result1 - result2) == 0):\n",
     "        print(\"Slices equivalent.\")\n",
     "    else:\n",
     "        print(\"Slices not equivalent (intensity differences).\")\n",


### PR DESCRIPTION
Calling GetArrayViewFromImage with a temporary SimpleITK image can
lead to unexpected behavior. The Python garbage collector may
delete the temporary image and then the view becomes
invalid. Replace with a call to GetArrayFromImage
(returns a copy of the array).