### PR TITLE
Adding Python 3.10 to testing.

### DIFF
--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -30,7 +30,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
SimpleITK added support for Python 3.10 in the previous release, v2.1.1.1, add
corresponding notebook testing.