### PR TITLE
Address CI running time problems.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,5 +82,6 @@ jobs:
       run: python Utilities/downloaddata.py Data/ Data/manifest.json
     - name: run the test
       env: 
+        ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS: 1
         SIMPLE_ITK_MEMORY_CONSTRAINED_ENVIRONMENT: 1
       run: pytest -v --tb=short tests/test_notebooks.py::Test_notebooks::test_python_notebook


### PR DESCRIPTION
Set the default number of ITK threads to 1. Address the low computational power of the github hosted runners (Win/linux 2CPU, 7GB RAM, 14GB SSD).