### PR TITLE
Change enchant installation on ubuntu.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
           sudo apt-get update
-          sudo apt-get install enchant
+          sudo apt-get install enchant-2
         elif [ "$RUNNER_OS" == "macOS" ]; then
           brew update
           brew install enchant


### PR DESCRIPTION
The enchant package is not available with ubuntu 22.04 (GitHub actions ubuntu-latest), so switch to enchant-2.