### PR TITLE
Replacing deprecated docker.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: circleci/python:3.9.7
+      - image: cimg/python:3.9
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The circleci/python:3.9.7 docker image was deprecated in favor of cimg/python:3.9. See:
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034#deprecated-images-3