### PR TITLE
Adding information on the difference between binary and ascii IO.

### DIFF
--- a/Python/22_Transforms.ipynb
+++ b/Python/22_Transforms.ipynb
@@ -65,6 +65,7 @@
    "source": [
     "import SimpleITK as sitk\n",
     "import numpy as np\n",
+    "import os\n",
     "\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
@@ -1483,6 +1484,8 @@
     "\n",
     "The SimpleITK.ReadTransform() returns a SimpleITK.Transform . The content of the file can be any of the SimpleITK transformations or a composite (set of transformations). \n",
     "\n",
+    "The transformation file formats supported by SimpleITK include *.txt*, *.tfm*, *.xfm*, *.hdf* and *.mat*. The former three are ASCII based formats and are more appropriate for saving global domain transformations, which are also easily understood by a human reader due to their limited number of parameters. The later two, *.hdf* and *.mat*, are binary formats and more appropriate for saving bounded domain transformations as those have a large number of parameters which are better saved using a binary file, faster IO, and also not readily understood by a human reader.\n",
+    "\n",
     "**Note**: Writing of nested composite transforms is not supported, you will need to \"flatten\" the transform before writing it to file."
    ]
   },
@@ -1494,8 +1497,6 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
     "# Create a 2D rigid transformation, write it to disk and read it back.\n",
     "basic_transform = sitk.Euler2DTransform()\n",
     "basic_transform.SetTranslation((1, 2))\n",
@@ -1559,6 +1560,48 @@
     "        f\"Nested composite transform after flattening contains {composite_transform.GetNumberOfTransforms()} transforms.\"\n",
     "    )\n",
     "    sitk.WriteTransform(composite_transform, full_file_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the next cells we create a displacement field which has a nominal size for a CT/MR 512x512x100. We then save it using a text format and a binary format illustrating that IO is orders of magnitude faster when using the binary format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "displacement_field_transform = sitk.DisplacementFieldTransform(\n",
+    "    sitk.GetImageFromArray(np.random.random([100, 512, 512, 3]))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit -r1 -n1\n",
+    "sitk.WriteTransform(\n",
+    "    displacement_field_transform, os.path.join(OUTPUT_DIR, \"deformation.tfm\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit -r1 -n1\n",
+    "sitk.WriteTransform(\n",
+    "    displacement_field_transform, os.path.join(OUTPUT_DIR, \"deformation.hdf\")\n",
+    ")"
    ]
   }
  ],

--- a/tests/additional_dictionary.txt
+++ b/tests/additional_dictionary.txt
@@ -16,6 +16,7 @@ BSplineTransform
 BSplineTransformInitializer
 BSplineTransformInitializerFilter
 Baum
+Bérard
 Biancardi
 Bimodal
 BinaryMorphologicalClosing
@@ -26,7 +27,6 @@ Biomechanics
 Bitwise
 Broyden
 Bruker
-Bérard
 CBCT
 CIRS
 CREATIS
@@ -165,6 +165,7 @@ LabelToRGBImageFilter
 LandmarkBasedTransformInitializer
 LaplacianSegmentation
 Lasser
+Léon
 Levelset
 Leygue
 Lim
@@ -172,7 +173,6 @@ Lingala
 Linte
 LoadPrivateTagsOn
 Lobb
-Léon
 MATLAB
 MATLAB's
 MAXXY
@@ -397,6 +397,7 @@ glyphs
 greyscale
 gui
 hausdorff
+hdf
 homography
 honours
 iff
@@ -595,6 +596,7 @@ vz
 widgetsnbextension
 wikimedia
 workflow
+xfm
 xn
 xpixels
 xtable


### PR DESCRIPTION
Previously the example only included ascii IO. This is useful for all global transformation but is problematic for the deformation field or BSpline. Added example illustrates the difference and why you need to use a binary format for the local transformation types.