### PR TITLE
Update circleci osx configuration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ executors:
       xcode: 13.4.1
     environment:
       RUNNER_OS: macos
+    resource_class: macos.x86.medium.gen2
 
 jobs:
   lint:


### PR DESCRIPTION
Getting close to end-of-life the medium macOS resource which is replaced by the macos.x86.medium.gen2. The workflow file previously did not specify the resource, so used default of medium. We now explicitly specify the resource.