### PR TITLE
Address change in nbconvert behavior.

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -318,8 +318,11 @@ class Test_notebooks(object):
 
         # Execute the notebook and allow errors (run all cells), output is
         # written to a temporary file which is automatically deleted.
-        # The delete=False is here to address an issue that Windows that seems to have with temporary files (see https://bugs.python.org/issue14243).
+        # The delete=False is here to address an issue that Windows has with temporary files.
+        # On windows, if delete=True the file is kept open and cannot be read from.
+        # (see https://github.com/python/cpython/issues/58451).
         with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as fout:
+            output_dir, output_fname = os.path.split(fout.name)
             args = [
                 "jupyter",
                 "nbconvert",
@@ -329,8 +332,10 @@ class Test_notebooks(object):
                 "--ExecutePreprocessor.kernel_name=" + kernel_name,
                 "--ExecutePreprocessor.allow_errors=True",
                 "--ExecutePreprocessor.timeout=6000",  # seconds till timeout
+                "--output-dir",
+                output_dir,
                 "--output",
-                fout.name,
+                output_fname,
                 path,
             ]
             subprocess.check_call(args)


### PR DESCRIPTION
The nbconvert --output parameter used to point to the full path to the output file. It now only points to the output file name. The directory is specified with the --output-dir.