### PR TITLE
Updates to circleci yaml.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ executors:
       xcode: 13.4.1
     environment:
       RUNNER_OS: macos
+    resource_class: macos.x86.medium.gen2
 
 jobs:
   lint:
@@ -83,7 +84,7 @@ jobs:
             python Utilities/downloaddata.py Data/ Data/manifest.json
       - run:
           name: run the test
-          no_output_timeout: 45m
+          no_output_timeout: 1h
           command: |
             export SIMPLE_ITK_MEMORY_CONSTRAINED_ENVIRONMENT=1
             export PYTHONUNBUFFERED=1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,5 +3,5 @@ pytest
 markdown
 lxml
 pyenchant
-ipython
+ipython<=8.12
 -rPython/requirements.txt


### PR DESCRIPTION
Getting close to end-of-life the medium macOS resource which is replaced by the macos.x86.medium.gen2. The workflow file previously did not specify the resource, so used default of medium. We now explicitly specify the resource.

Increased the allowed no output timeout to 1 hour.