### PR TITLE
Jupyter notebook 7 automatically activates the ipywidgets extension.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ jobs:
             which python
             python -m pip install --upgrade pip
             python -m pip install -r requirements_dev.txt
-            python -m jupyter nbextension enable --py --sys-prefix widgetsnbextension
       - run:
           name: Download data
           command: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements_dev.txt
-        jupyter nbextension enable --py --sys-prefix widgetsnbextension
     - name: Install SimpleITK from test PyPi from manually launched workflow
       if: ${{ inputs.testPyPi }}
       run: pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple SimpleITK

--- a/Python/00_Setup.ipynb
+++ b/Python/00_Setup.ipynb
@@ -116,7 +116,7 @@
    "source": [
     "Now we check that the ipywidgets will display correctly. When you run the following cell you should see a slider.\n",
     "\n",
-    "If you don't see a slider please shutdown the Jupyter server, at the command line prompt press Control-c twice, and then run the following command:\n",
+    "If you don't see a slider please shutdown the Jupyter server, at the command line prompt press Control-c twice, and then run the following command (jupyter notebook 5.2 or earlier):\n",
     "\n",
     "```jupyter nbextension enable --py --sys-prefix widgetsnbextension```"
    ]

--- a/Python/README.md
+++ b/Python/README.md
@@ -35,11 +35,16 @@ Activate the virtual environment:
 On windows: ```sitkpy\Scripts\activate.bat```  
 On linux/osx: ```source sitkpy/bin/activate```
 
-Install all of the required packages and activate the ipywidgets notebook extension.
+Install all of the required packages.
 ```
 pip install -r Python/requirements.txt
+```
+
+On Jupyter Notebooks version 5.2 or older activate the ipywidgets notebook extension:
+```
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
 ```
+
 The requirements.txt file lists the required packages ([see here](requirements.txt)).
 
 **Run the notebooks**


### PR DESCRIPTION
Enabling the ipywidgets extension is no longer an option with jupyter notebook 7, it is done automatically.