### PR TITLE
Repeated resampling anti-pattern example.

### DIFF
--- a/Python/21_Transforms_and_Resampling.ipynb
+++ b/Python/21_Transforms_and_Resampling.ipynb
@@ -1060,6 +1060,59 @@
     "    figure_size=[4, 4],\n",
     ");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Repeated Resampling - Just Say No\n",
+    "\n",
+    "Registration workflows that yield multiple transformations are relatively common. Many workflows use an incremental approach, starting with a transformation with a low dimensional parameter space followed by a transformation with a higher dimensional parameter space. For example, first estimating an affine transformation which is then followed by a BSpline transformation. A slightly different registration workflow that yields multiple transformations is the registration of a temporal sequence. In this context, neighboring frames are registered to each other with the goal of registering all images to a single frame. This workflow can yield long transformation sequences, K transformations that map between frame N and N+K.\n",
+    "\n",
+    "Once we have these multiple transformations we have two options, iterate over the transformations and repeatedly resample or compose the transformations and resample once. The first option, repeated resampling, is best avoided as it yields sub-optimal results. This is due to the bounded extent of the resampling grid and to the repeated use of interpolation. Note that once a resampling grid point is mapped outside the resampled image's physical region that intensity information is lost even if a consecutive transformation would map that point inside the image's physical region.\n",
+    "\n",
+    "The following code cell clearly illustrates the difference. If you think it is bit of an exaggeration, change the `num_transformations` to 2 and see that even with the minimal number of incremental transformations there is a difference between repeated resampling and transformation composing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_to_resample = sitk.ReadImage(fdata(\"cxr.dcm\"))[:, :, 0]\n",
+    "# 20 degree rotation around the image center\n",
+    "rotation2D = sitk.Euler2DTransform()\n",
+    "rotation2D.SetAngle(np.pi / 9)\n",
+    "rotation2D.SetCenter(\n",
+    "    image_to_resample.TransformContinuousIndexToPhysicalPoint(\n",
+    "        [(sz - 1) / 2 for sz in image_to_resample.GetSize()]\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# repeat the transformation num_transforms times\n",
+    "num_transforms = 10\n",
+    "transformations = [rotation2D] * num_transforms\n",
+    "\n",
+    "incremental_resampled_image = image_to_resample\n",
+    "# Follow the stack based convention used by the CompositeTransform, first in, last applied.\n",
+    "for tx in reversed(transformations):\n",
+    "    incremental_resampled_image = sitk.Resample(incremental_resampled_image, tx)\n",
+    "\n",
+    "composite_resampled_image = sitk.Resample(\n",
+    "    image_to_resample, sitk.CompositeTransform(transformations)\n",
+    ")\n",
+    "\n",
+    "gui.multi_image_display2D(\n",
+    "    [image_to_resample, incremental_resampled_image, composite_resampled_image],\n",
+    "    [\n",
+    "        \"original image\",\n",
+    "        \"incremental resampling\",\n",
+    "        \"transform composition and resampling\",\n",
+    "    ],\n",
+    "    figure_size=[10, 4],\n",
+    ");"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Example illustrating why transformation composition is preferred over repeated resampling.