### PR TITLE
Remove the use of pickling.

### DIFF
--- a/Python/71_Trust_But_Verify.ipynb
+++ b/Python/71_Trust_But_Verify.ipynb
@@ -69,7 +69,6 @@
     "\n",
     "import hashlib\n",
     "import tempfile\n",
-    "import pickle\n",
     "\n",
     "%matplotlib notebook\n",
     "import matplotlib.pyplot as plt\n",
@@ -652,7 +651,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We next run our visualization based analysis. For large datasets this may take some time, so we save the results via pickling so that we can look at them at a later point in time.\n",
+    "We next run our visualization based analysis. For large datasets this may take some time, so we save the results so that we can look at them at a later point in time.\n",
     "\n",
     "We start with the file based approach. Notice that with this approach the display is dominated by slices from several DICOM series. After selecting our images of interest we print the associated file names."
    ]
@@ -663,8 +662,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "faux_image_volume_file_name = os.path.join(OUTPUT_DIR, \"faux_image_volume.pkl\")\n",
-    "faux_image_file_list_name = os.path.join(OUTPUT_DIR, \"faux_image_file_list.pkl\")\n",
+    "faux_image_volume_file_name = os.path.join(OUTPUT_DIR, \"faux_image_volume.nrrd\")\n",
+    "faux_image_file_list_name = os.path.join(OUTPUT_DIR, \"faux_image_file_list.csv\")\n",
     "faux_volume_image_files, image_file_list = visualize_files(\n",
     "    data_root_dir,\n",
     "    imageIO=\"\",\n",
@@ -672,10 +671,9 @@
     "    thumbnail_size=[64, 64],\n",
     "    tile_size=[30, 20],\n",
     ")\n",
-    "with open(faux_image_volume_file_name, \"wb\") as fp:\n",
-    "    pickle.dump(faux_volume_image_files, fp)\n",
-    "with open(faux_image_file_list_name, \"wb\") as fp:\n",
-    "    pickle.dump(image_file_list, fp)"
+    "sitk.WriteImage(faux_volume_image_files, faux_image_volume_file_name, True)\n",
+    "df = pd.DataFrame(data=image_file_list, columns=[\"files\"])\n",
+    "df.to_csv(faux_image_file_list_name, index=False)"
    ]
   },
   {
@@ -684,10 +682,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(faux_image_volume_file_name, \"rb\") as fp:\n",
-    "    faux_volume_image_files = pickle.load(fp)\n",
-    "with open(faux_image_file_list_name, \"rb\") as fp:\n",
-    "    image_file_list = pickle.load(fp)\n",
+    "faux_volume_image_files = sitk.ReadImage(faux_image_volume_file_name)\n",
+    "image_file_list = pd.read_csv(faux_image_file_list_name)[\"files\"].to_list()\n",
     "\n",
     "image_selection_gui = ImageSelection(\n",
     "    faux_volume_image_files,\n",
@@ -722,15 +718,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "faux_series_volume_file_name = os.path.join(OUTPUT_DIR, \"faux_series_volume.pkl\")\n",
-    "faux_series_file_list_name = os.path.join(OUTPUT_DIR, \"faux_series_file_list.pkl\")\n",
+    "faux_series_volume_file_name = os.path.join(OUTPUT_DIR, \"faux_series_volume.nrrd\")\n",
+    "faux_series_file_list_name = os.path.join(OUTPUT_DIR, \"faux_series_file_list.csv\")\n",
     "faux_volume_image_files, image_file_list = visualize_series(\n",
     "    data_root_dir, projection_axis=2, thumbnail_size=[64, 64], tile_size=[30, 20]\n",
     ")\n",
-    "with open(faux_series_volume_file_name, \"wb\") as fp:\n",
-    "    pickle.dump(faux_volume_image_files, fp)\n",
-    "with open(faux_series_file_list_name, \"wb\") as fp:\n",
-    "    pickle.dump(image_file_list, fp)"
+    "sitk.WriteImage(faux_volume_image_files, faux_series_volume_file_name, True)\n",
+    "df = pd.DataFrame(data={\"files\": image_file_list})\n",
+    "df.to_csv(faux_series_file_list_name, index=False)"
    ]
   },
   {
@@ -739,10 +734,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(faux_series_volume_file_name, \"rb\") as fp:\n",
-    "    faux_volume_image_files = pickle.load(fp)\n",
-    "with open(faux_series_file_list_name, \"rb\") as fp:\n",
-    "    image_file_list = pickle.load(fp)\n",
+    "faux_volume_image_files = sitk.ReadImage(faux_series_volume_file_name)\n",
+    "image_file_list = pd.read_csv(faux_series_file_list_name)[\"files\"].apply(eval).to_list()\n",
     "\n",
     "image_selection_gui2 = ImageSelection(\n",
     "    faux_volume_image_files,\n",


### PR DESCRIPTION
The pickle format is brittle and not intended for long term storage of data. Changes of Python version or packages can make the stored data incompatible with the new data layout. Replaced pickling with saving to image file and csv.