### PR TITLE
Change runner from macos-latest to macos-13.

### DIFF
--- a/.github/workflows/scheduled_or_manual.yml
+++ b/.github/workflows/scheduled_or_manual.yml
@@ -34,8 +34,8 @@ jobs:
   test:
     needs: lint
     strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
+      matrix: #using macos-13 because pyenchant doesn't work on macos-latest (macos 14, arm64 architecture)
+        os: [macos-13, windows-latest]
         python-version: ['3.8', '3.11']
         inputs: ["00_ or 01_ or 02_ or 03_ or 04_ or 05_ or 10_ or 20_ or 21_ or 22_ or 300_ or 30_ or 31_ or 32_ or 33_ or 34_ or 35_ or 36_", "51_ or 55_ or 56_ or 60_ or 61_ or 62_ or 63_ or 64_", "65_ or 66_ or 67_ or 68_ or 69_ or 70_ or 71_"]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The macos-latest is now macos-14 and arm64 architecture. The pyenchant package for spell checking does not work for this new setup, so tests fail. Using the older macos-13 and intel architecture resolves the issue for now.