### PR TITLE
Change runner from macos-latest to macos-13.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
   test:
     needs: lint
     strategy:
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+      matrix: #using macos-13 because pyenchant doesn't work on macos-latest (macos 14, arm64 architecture)
+        os: [macos-13, windows-latest, ubuntu-latest]
         python-version: ['3.8', '3.11']
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The pyenchant package for spell checking is not available for macos-latest (macos-14, arm64 architecture).