### PR TITLE
Updating the ipython magic for interactive matplotlib.

### DIFF
--- a/Python/04_Image_Display.ipynb
+++ b/Python/04_Image_Display.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "import SimpleITK as sitk\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import matplotlib.pyplot as plt\n",
     "import gui\n",
     "\n",

--- a/Python/05_Results_Visualization.ipynb
+++ b/Python/05_Results_Visualization.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "\n",
     "import numpy as np\n",
     "import itertools\n",

--- a/Python/21_Transforms_and_Resampling.ipynb
+++ b/Python/21_Transforms_and_Resampling.ipynb
@@ -742,7 +742,7 @@
    "outputs": [],
    "source": [
     "# Temporarily change the matplotlib back-end to enable mouse interaction\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "intensity_profiles_image = sitk.ReadImage(fdata(\"training_001_ct.mha\"))\n",
     "point_gui = gui.PointDataAquisition(image=intensity_profiles_image);"
    ]

--- a/Python/30_Segmentation_Region_Growing.ipynb
+++ b/Python/30_Segmentation_Region_Growing.ipynb
@@ -23,8 +23,8 @@
    "outputs": [],
    "source": [
     "# To use interactive plots (mouse clicks, zooming, panning) we use the notebook back end. We want our graphs\n",
-    "# to be embedded in the notebook, inline mode, this combination is defined by the magic \"%matplotlib notebook\".\n",
-    "%matplotlib notebook\n",
+    "# to be embedded in the notebook, inline mode, this combination is defined by the magic \"%matplotlib widget\".\n",
+    "%matplotlib widget\n",
     "\n",
     "import SimpleITK as sitk\n",
     "\n",

--- a/Python/33_Segmentation_Thresholding_Edge_Detection.ipynb
+++ b/Python/33_Segmentation_Thresholding_Edge_Detection.ipynb
@@ -29,7 +29,7 @@
     "%run update_path_to_download_script\n",
     "from downloaddata import fetch_data as fdata\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import gui\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/Python/35_Segmentation_Shape_Analysis.ipynb
+++ b/Python/35_Segmentation_Shape_Analysis.ipynb
@@ -25,7 +25,7 @@
     "import SimpleITK as sitk\n",
     "import pandas as pd\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import gui\n",

--- a/Python/36_Microscopy_Colocalization_Distance_Analysis.ipynb
+++ b/Python/36_Microscopy_Colocalization_Distance_Analysis.ipynb
@@ -26,7 +26,7 @@
     "import pandas as pd\n",
     "\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import gui\n",
     "\n",
     "%run update_path_to_download_script\n",

--- a/Python/63_Registration_Initialization.ipynb
+++ b/Python/63_Registration_Initialization.ipynb
@@ -62,7 +62,7 @@
     "%run update_path_to_download_script\n",
     "from downloaddata import fetch_data as fdata\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import gui\n",
     "\n",
     "\n",

--- a/Python/67_Registration_Semiautomatic_Homework.ipynb
+++ b/Python/67_Registration_Semiautomatic_Homework.ipynb
@@ -33,8 +33,8 @@
    "outputs": [],
    "source": [
     "# To use interactive plots (mouse clicks, zooming, panning) we use the notebook back end. We want our graphs\n",
-    "# to be embedded in the notebook, inline mode, this combination is defined by the magic \"%matplotlib notebook\".\n",
-    "%matplotlib notebook\n",
+    "# to be embedded in the notebook, inline mode, this combination is defined by the magic \"%matplotlib widget\".\n",
+    "%matplotlib widget\n",
     "\n",
     "import numpy as np\n",
     "import SimpleITK as sitk\n",

--- a/Python/68_Registration_Errors.ipynb
+++ b/Python/68_Registration_Errors.ipynb
@@ -44,7 +44,7 @@
     "import numpy as np\n",
     "import copy\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "from gui import PairedPointDataManipulation, display_errors\n",
     "import matplotlib.pyplot as plt\n",
     "from registration_utilities import registration_errors"

--- a/Python/69_x-ray-panorama.ipynb
+++ b/Python/69_x-ray-panorama.ipynb
@@ -43,7 +43,7 @@
     "import os.path\n",
     "import copy\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import gui\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/Python/70_Data_Augmentation.ipynb
+++ b/Python/70_Data_Augmentation.ipynb
@@ -22,7 +22,7 @@
     "import SimpleITK as sitk\n",
     "import numpy as np\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import gui\n",
     "\n",
     "# utility method that either downloads data from the Girder repository or\n",

--- a/Python/71_Trust_But_Verify.ipynb
+++ b/Python/71_Trust_But_Verify.ipynb
@@ -70,7 +70,7 @@
     "import hashlib\n",
     "import tempfile\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import matplotlib.pyplot as plt\n",
     "import ipywidgets as widgets\n",
     "\n",

--- a/Python/environment.yml
+++ b/Python/environment.yml
@@ -5,11 +5,12 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.9
+  - python=3.11
   - requests
   - jupyter
   - matplotlib
   - ipywidgets
+  - ipympl
   - numpy
   - scipy
   - pandas

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -2,6 +2,7 @@ SimpleITK>2.2.1
 jupyter
 matplotlib
 ipywidgets
+ipympl
 numpy
 scipy
 pandas

--- a/environment.yml
+++ b/environment.yml
@@ -5,11 +5,12 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.9
+  - python=3.11
   - requests
   - jupyter
   - matplotlib
   - ipywidgets
+  - ipympl
   - numpy
   - scipy
   - pandas


### PR DESCRIPTION
Interactive usage of matplotlib in Jupyter notebooks/JupyterLab requires installation of the ipympl backend. Additionally, usage of the ipython magic changed from %matplotlib notebook (used in classic notebook<7) to %matplotlib widget.

https://matplotlib.org/stable/users/explain/figure/interactive.html#jupyter-notebooks-jupyterlab