### PR TITLE
Remove tainted default channel

### DIFF
--- a/Python/environment.yml
+++ b/Python/environment.yml
@@ -1,7 +1,6 @@
 name: sitkpy
 
 channels:
-  - defaults
   - conda-forge
 
 dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: sitkpy
 
 channels:
-  - defaults
   - conda-forge
 
 dependencies:


### PR DESCRIPTION
Lately, Anaconda has taken to enforcing the terms of service for large (>200 people) organizations using their `default` channel. Doing so is their legal right, but the fact is that open-source software built on conda-forge packages does not actually need the default channel to be enabled—better to just purge it, to make that as clear as possible, legally.

See:
* https://www.anaconda.com/blog/is-conda-free
* https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/
