### PR TITLE
Change test output due to change in ITK/GDCM.

### DIFF
--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -46,7 +46,7 @@ class TestScripts:
             (
                 "per_file_data_characteristics.csv",
                 "per_file",
-                "912ede9ecfe519346f3a519f59215f6d",
+                "c1e073943a1e6160350df2376db42b12",
             ),
             (
                 "per_series_data_characteristics.csv",


### PR DESCRIPTION
The spacing parameter on the z axis when reading a single image changed between ITK 5.3 and 5.4. Issue with change raised here: https://github.com/InsightSoftwareConsortium/ITK/issues/4794

This is due to the underlying change in GDCM
(MediaStorage::SecondaryCaptureImageStorage deriving the z spacing from this information):
https://github.com/malaterre/GDCM/commit/836f7a7454ae0edd2713ecb60d66da11349d3a0d