### PR TITLE
Correct parameter passing to sitk.IntensityWindowing.

### DIFF
--- a/Python/scripts/characterize_data.py
+++ b/Python/scripts/characterize_data.py
@@ -552,11 +552,11 @@ def image_to_thumbnail(img, thumbnail_sizes, interpolator, projection_axis):
                 outputMaximum=255.0,
             )
             img = sitk.Cast(wl_image, sitk.sitkUInt8)
-        else:
+        else:  # pixel type of uint8
             img = sitk.IntensityWindowing(
-                img,
-                windowMinimum=np.min(sitk.GetArrayViewFromImage(img)),
-                windowMaximum=np.max(sitk.GetArrayViewFromImage(img)),
+                img,  # numpy returns its own type np.uint8 which isn't converted implicitly by SimpleITK
+                windowMinimum=int(np.min(sitk.GetArrayViewFromImage(img))),
+                windowMaximum=int(np.max(sitk.GetArrayViewFromImage(img))),
             )
     # Computations below are simplified if we assume image axes are the
     # standard basis. This is reasonable for the purpose of creating a


### PR DESCRIPTION
Numpy min/max return a np.uint8 type which is not explicitly converted to the expected C++ data type in SimpleITK. Explicitly converting it to int resolves the issue.