### PR TITLE
Improve parallelization and user feedback.

### DIFF
--- a/Data/characterize_data_user_defaults.json
+++ b/Data/characterize_data_user_defaults.json
@@ -1,8 +1,6 @@
 {
   "max_processes": 6,
-  "series_tags": [
-    "0020|000e",
-    "0020|000d",
+  "additional_series_tags": [
     "0020|0011",
     "0018|0024",
     "0018|0050",

--- a/Python/environment.yml
+++ b/Python/environment.yml
@@ -14,5 +14,5 @@ dependencies:
   - scipy
   - pandas
   - numba
-  - multiprocess
+  - tqdm
   - SimpleITK>2.2.1

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -7,6 +7,6 @@ numpy
 scipy
 pandas
 numba
-multiprocess
+tqdm
 requests
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,5 @@ dependencies:
   - scipy
   - pandas
   - numba
-  - multiprocess
+  - tqdm
   - SimpleITK>2.2.1

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -47,13 +47,13 @@ class TestScripts:
                 "per_file_data_characteristics.csv",
                 "per_file",
                 "characterize_data_user_defaults.json",
-                "bdb2f2489287cf43b681afce1b5d00e8",
+                "fb0338866794ef68c5d5854399ccd22c",
             ),
             (
                 "per_series_data_characteristics.csv",
                 "per_series",
                 "characterize_data_user_defaults.json",
-                "1c78bf68faf7f1a8fdb29e14ae276565",
+                "766184c8503a2f08cac6e3b6be57e346",
             ),
         ],
     )


### PR DESCRIPTION
Switch from the multiprocess package to use concurrent.futures.

Introduce the usage of the tqdm package for displaying progress when used in interactive mode. There is an option to disable the progress reporting if using a scheduling system on a cluster and there is no need for visual dispaly.

Add scatterplot output of image pixel sizes.