### PR TITLE
Reverting the removal of multiprocess from config files.

### DIFF
--- a/Python/environment.yml
+++ b/Python/environment.yml
@@ -14,5 +14,6 @@ dependencies:
   - scipy
   - pandas
   - numba
+  - multiprocess
   - tqdm
   - SimpleITK>2.2.1

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -7,6 +7,7 @@ numpy
 scipy
 pandas
 numba
+multiprocess
 tqdm
 requests
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,6 @@ dependencies:
   - scipy
   - pandas
   - numba
+  - multiprocess
   - tqdm
   - SimpleITK>2.2.1


### PR DESCRIPTION
The multiprocess was replaced with concurrent.futures in the characterize_data Python script. While making that change it was removed from the environment configuration files. This was an error as the package is used in the notebooks but those are not tested when only the script is modified.