### PR TITLE
Update CircleCI badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SimpleITK Notebooks
 
 ![GitHub Actions Notebook Testing](https://github.com/InsightSoftwareConsortium/SimpleITK-Notebooks/actions/workflows/main.yml/badge.svg
-)&nbsp;&nbsp;[![CircleCI Notebook Testing](https://dl.circleci.com/status-badge/img/gh/InsightSoftwareConsortium/SimpleITK-Notebooks/tree/master.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/InsightSoftwareConsortium/SimpleITK-Notebooks/tree/master)
+)&nbsp;&nbsp;[![CircleCI Notebook Testing](https://dl.circleci.com/status-badge/img/gh/InsightSoftwareConsortium/SimpleITK-Notebooks/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/InsightSoftwareConsortium/SimpleITK-Notebooks/tree/main)
 &nbsp;&nbsp;[![http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/)
 &nbsp;&nbsp;[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 


### PR DESCRIPTION
The CircleCI badge was pointing to a build that doesn't exist anymore, master branch. Changed it to point to main.