### PR TITLE
Replace the usage of widget with ipympl.

### DIFF
--- a/Python/03_Image_Details.ipynb
+++ b/Python/03_Image_Details.ipynb
@@ -1436,7 +1436,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "import gui\n",
     "\n",
     "gui.RegistrationPointDataAquisition(\n",

--- a/Python/04_Image_Display.ipynb
+++ b/Python/04_Image_Display.ipynb
@@ -57,7 +57,7 @@
    "source": [
     "import SimpleITK as sitk\n",
     "\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "import gui\n",
     "\n",

--- a/Python/05_Results_Visualization.ipynb
+++ b/Python/05_Results_Visualization.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "\n",
     "import numpy as np\n",
     "import itertools\n",

--- a/Python/21_Transforms_and_Resampling.ipynb
+++ b/Python/21_Transforms_and_Resampling.ipynb
@@ -774,7 +774,7 @@
    "outputs": [],
    "source": [
     "# Temporarily change the matplotlib back-end to enable mouse interaction\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "intensity_profiles_image = sitk.ReadImage(fdata(\"training_001_ct.mha\"))\n",
     "point_gui = gui.PointDataAquisition(image=intensity_profiles_image);"
    ]

--- a/Python/30_Segmentation_Region_Growing.ipynb
+++ b/Python/30_Segmentation_Region_Growing.ipynb
@@ -60,9 +60,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To use interactive plots (mouse clicks, zooming, panning) we use the notebook back end. We want our graphs\n",
-    "# to be embedded in the notebook, inline mode, this combination is defined by the magic \"%matplotlib widget\".\n",
-    "%matplotlib widget\n",
+    "# To use interactive plots (mouse clicks, zooming, panning) we use the ipympl back end. We want our graphs\n",
+    "# to be embedded in the notebook, inline mode, this combination is defined by the magic \"%matplotlib ipympl\".\n",
+    "%matplotlib ipympl\n",
     "\n",
     "import SimpleITK as sitk\n",
     "\n",

--- a/Python/33_Segmentation_Thresholding_Edge_Detection.ipynb
+++ b/Python/33_Segmentation_Thresholding_Edge_Detection.ipynb
@@ -67,7 +67,7 @@
     "%run update_path_to_download_script\n",
     "from downloaddata import fetch_data as fdata\n",
     "\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "import gui\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/Python/35_Segmentation_Shape_Analysis.ipynb
+++ b/Python/35_Segmentation_Shape_Analysis.ipynb
@@ -25,7 +25,7 @@
     "import SimpleITK as sitk\n",
     "import pandas as pd\n",
     "\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import gui\n",

--- a/Python/36_Microscopy_Colocalization_Distance_Analysis.ipynb
+++ b/Python/36_Microscopy_Colocalization_Distance_Analysis.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "import gui\n",
     "\n",
     "%run update_path_to_download_script\n",

--- a/Python/63_Registration_Initialization.ipynb
+++ b/Python/63_Registration_Initialization.ipynb
@@ -62,7 +62,7 @@
     "%run update_path_to_download_script\n",
     "from downloaddata import fetch_data as fdata\n",
     "\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "import gui\n",
     "\n",
     "\n",

--- a/Python/67_Registration_Semiautomatic_Homework.ipynb
+++ b/Python/67_Registration_Semiautomatic_Homework.ipynb
@@ -70,9 +70,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To use interactive plots (mouse clicks, zooming, panning) we use the notebook back end. We want our graphs\n",
-    "# to be embedded in the notebook, inline mode, this combination is defined by the magic \"%matplotlib widget\".\n",
-    "%matplotlib widget\n",
+    "# To use interactive plots (mouse clicks, zooming, panning) we use the ipympl back end. We want our graphs\n",
+    "# to be embedded in the notebook, inline mode, this combination is defined by the magic \"%matplotlib ipympl\".\n",
+    "%matplotlib ipympl\n",
     "\n",
     "import numpy as np\n",
     "import SimpleITK as sitk\n",

--- a/Python/68_Registration_Errors.ipynb
+++ b/Python/68_Registration_Errors.ipynb
@@ -82,7 +82,7 @@
     "import numpy as np\n",
     "import copy\n",
     "\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "from gui import PairedPointDataManipulation, display_errors\n",
     "import matplotlib.pyplot as plt\n",
     "from registration_utilities import registration_errors"

--- a/Python/69_x-ray-panorama.ipynb
+++ b/Python/69_x-ray-panorama.ipynb
@@ -80,7 +80,7 @@
     "import os.path\n",
     "import copy\n",
     "\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "import gui\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/Python/70_Data_Augmentation.ipynb
+++ b/Python/70_Data_Augmentation.ipynb
@@ -60,7 +60,7 @@
     "import SimpleITK as sitk\n",
     "import numpy as np\n",
     "\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "import gui\n",
     "\n",
     "# utility method that either downloads data from the Girder repository or\n",

--- a/Python/71_Trust_But_Verify.ipynb
+++ b/Python/71_Trust_But_Verify.ipynb
@@ -71,7 +71,7 @@
     "import hashlib\n",
     "import tempfile\n",
     "\n",
-    "%matplotlib widget\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "import ipywidgets as widgets\n",
     "\n",

--- a/tests/additional_dictionary.txt
+++ b/tests/additional_dictionary.txt
@@ -1,3 +1,4 @@
+ipympl
 ACM
 ANTSNeighborhoodCorrelation
 API


### PR DESCRIPTION
The "widget" backend is an alias to the ipympl backend. The associated package is ipympl. By using the ipympl backend in the ipython magic, the dependency on the ipympl package is made explicit and clear to the user.