### PR TITLE
Change the Python versions in the CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.13
     steps:
       - checkout
       - run:
@@ -111,7 +111,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              python-version: ['3.9', '3.12']
+              python-version: ['3.10', '3.13']
               os: ["linux"]
           requires:
             - lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Install and run black for notebooks
       run: |
         python -m pip install --upgrade pip
@@ -33,15 +33,9 @@ jobs:
   test:
     needs: lint
     strategy:
-      matrix: #using macos-15-intel, last available intel architecture. macos-latest is arm64 architecture.
-        os: [macos-15-intel, windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.12']
-        # Combination of old architecture, macos-intel, and new python, 3.12, causes issues:
-        # llvmlite is not available for this combination from PyPI so skip that testing.
-        # It is available from conda-forge so not completely unsupported.
-        exclude:
-          - os: macos-15-intel
-            python-version: '3.12'
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ['3.10', '3.13']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/scheduled_or_manual.yml
+++ b/.github/workflows/scheduled_or_manual.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Install and run black for notebooks
       run: |
         python -m pip install --upgrade pip
@@ -34,15 +34,9 @@ jobs:
   test:
     needs: lint
     strategy:
-      matrix: #using macos-15-intel, last available intel architecture. macos-latest is arm64 architecture.
-        os: [macos-15-intel, windows-latest, macos-latest]
-        python-version: ['3.9', '3.12']
-        # Combination of old architecture, macos-intel, and new python, 3.12, causes issues:
-        # llvmlite is not available for this combination from PyPI so skip that testing.
-        # It is available from conda-forge so not completely unsupported.
-        exclude:
-          - os: macos-15-intel
-            python-version: '3.12'
+      matrix:
+        os: [windows-latest, macos-latest]
+        python-version: ['3.10', '3.13']
         inputs: ["00_ or 01_ or 02_ or 03_ or 04_ or 05_ or 10_ or 20_ or 21_ or 22_ or 300_ or 30_ or 31_ or 32_ or 33_ or 34_ or 35_ or 36_", "51_ or 55_ or 56_ or 60_ or 61_ or 62_ or 63_ or 64_", "65_ or 66_ or 67_ or 68_ or 69_ or 70_ or 71_"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Change tested versions from 3.9 and 3.12 to 3.10 and 3.13. Python 3.9 reached its end of life on October 31 2025.