### PR TITLE
Remove deprecated and unused import distutils.

### DIFF
--- a/Python/00_Setup.ipynb
+++ b/Python/00_Setup.ipynb
@@ -35,7 +35,6 @@
    "outputs": [],
    "source": [
     "import importlib\n",
-    "from distutils.version import LooseVersion\n",
     "\n",
     "# check that all packages are installed (see requirements.txt file)\n",
     "required_packages = {\n",


### PR DESCRIPTION
Old import of distutils that was removed in Python 3.12 detected due to changes in pip.

Previously pip included setuptools as default
dependency and that included distutils so did not
cause issues. Pip no longer includes setuptools
as defualt dependency, so exposed the issue.