### PR TITLE
Add CITATIONS.bib file used by GitHub hook.

### DIFF
--- a/CITATIONS.bib
+++ b/CITATIONS.bib
@@ -1,0 +1,10 @@
+@Article{yaniv2018,
+author  = {Ziv Yaniv and Bradley C. Lowekamp and Hans J. Johnson and Richard Beare},
+title   = {{SimpleITK} Image-Analysis Notebooks: A Collaborative Environment for Education and Reproducible Research},
+doi     = {10.1007/s10278-017-0037-8},
+number  = {3},
+pages   = {290--303},
+volume  = {31},
+journal = {Journal of Digital Imaging},
+year    = {2018},
+}


### PR DESCRIPTION
GitHub adds a citation dropdown if this file is present in the repository root directory. Also, allows users to easily copy-paste the ciation information into a bibliography manager. Content of file matches existing "How to Cite" README section.